### PR TITLE
Minor updates

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -321,7 +321,8 @@ li.md-nav__item,
   }
 
   .md-nav--secondary {
-    border: var(--md-border-width) solid var(--md-border-color);
+    /* TODO: Add this back after all pages have been updated for ## Title usage  */
+    /* border: var(--md-border-width) solid var(--md-border-color); */ 
     border-radius: var(--md-border-radius);
     width: fit-content;
     padding: 1em;

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -683,6 +683,12 @@ pre .md-clipboard {
   height: 3px;
 }
 
+.md-typeset .tabbed-block p,
+.md-typeset .tabbed-block ul,
+.md-typeset .tabbed-block ol {
+  margin: 1em;
+}
+
 /* Document date styling */
 .md-source-file small {
   display: flex;

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -940,7 +940,7 @@ pre .md-clipboard {
 }
 
 .md-typeset .grid {
-  grid-gap: 3rem;
+  grid-gap: 1rem;
 }
 
 .md-typeset .grid>div:first-child>p:first-child {

--- a/material-overrides/main-index-page.html
+++ b/material-overrides/main-index-page.html
@@ -31,18 +31,7 @@
         {% endif %}
       {% endfor %}
     {% endif %}
-    <div class="disclaimer">All information made available, including claims, content, designs, algorithms, estimates,
-          roadmaps, specifications, and performance measurements described in this project are provided for informational
-          purposes only and Moonbeam does not endorse any project referenced here. It is up to the reader to check and
-          validate the accuracy and truthfulness. Furthermore, nothing in this project information constitutes a
-          solicitation for investment. No developer or entity involved in creating the Moonbeam Network or Moonriver
-          Network or authoring this information will be liable for any claims or damages whatsoever associated with your
-          use, inability to use, or your interaction with other users of, the Moonbeam Network or Moonriver Network or any
-          information made available on this website, including any direct, indirect, incidental, special, exemplary,
-          punitive or consequential damages, or loss of profits, cryptocurrencies, tokens, or anything else of value. All
-          information contained herein is subject to modification without notice.
-    </div>
-  </div>
+    <!-- <div class="disclaimer"></div> -->
 {% endblock %}
 
 {% block site_nav %}

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -58,8 +58,8 @@
           <span>Made with 🩵 by <a href="https://papermoon.io/" target="_blank">PaperMoon</a></span>
         </div>
         <div class="policy-links">
-          <a href="https://moonbeam.network/terms-of-use" target="_blank">Terms of use</a>
-          <a href="https://moonbeam.network/privacy-policy" target="_blank">Privacy policy</a>
+          <a href="https://wormhole.com/pages/terms-of-use" target="_blank">Terms of use</a>
+          <a href="https://wormhole.com/pages/data-protection-and-privacy-policy" target="_blank">Privacy policy</a>
         </div>
       </div>
     </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,9 +57,7 @@ markdown_extensions:
 plugins:
   - search
   - awesome-pages
-  # - git-revision-date-localized:
-  #     enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
-  #     enable_creation_date: !!bool true
+  - glightbox
   - redirects:
       redirect_maps:
         # Redirects will go here as pages get moved around in the following format:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ MarkupSafe==2.1.2
 mkdocs==1.6.0
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-git-revision-date-localized-plugin==1.2.0
+mkdocs-glightbox==0.4.0
 mkdocs-macros-plugin==0.7.0
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.5.24


### PR DESCRIPTION
This PR does the following:

- Updates the privacy and terms of use links
- Removes the disclaimer
- Adds the glightbox plugin, so users can click on an image to zoom into it without leaving the page or modifying their browser zoom (see image below)
- Fixes text elements in tabs

<img width="1792" alt="Screenshot 2024-08-28 at 10 34 57 PM" src="https://github.com/user-attachments/assets/2b650c2c-20d3-499a-80f2-227886c33f07">
