### PR TITLE
Update styling for index pages

### DIFF
--- a/material-overrides/assets/stylesheets/index-page.css
+++ b/material-overrides/assets/stylesheets/index-page.css
@@ -53,3 +53,10 @@
 .md-nav--secondary {
   display: none;
 }
+
+@media screen and (min-width: 76.25em) {
+  .main-page-sidebar .md-nav__item .md-nav__link-wrapper.md-nav__link--active a,
+  .main-page-sidebar .md-nav__item .md-nav__link--active a {
+    margin-left: 0;
+  }
+}

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -951,6 +951,27 @@ pre .md-clipboard {
   margin-top: 0;
 }
 
+.md-typeset .grid.cards>ol>li,
+.md-typeset .grid.cards>ul>li,
+.md-typeset .grid>.card {
+  background-color: var(--grey);
+  border: var(--md-border-width) solid var(--md-border-color);
+}
+
+.md-typeset .grid.cards>ol>li:focus-within,
+.md-typeset .grid.cards>ol>li:hover,
+.md-typeset .grid.cards>ul>li:focus-within,
+.md-typeset .grid.cards>ul>li:hover,
+.md-typeset .grid>.card:focus-within,
+.md-typeset .grid>.card:hover {
+  border: var(--md-border-width) solid var(--md-border-color);
+}
+
+.md-typeset .grid.half {
+  grid-template-columns: repeat(auto-fit, minmax(50%, 0fr));
+  margin: 1em 1.4em 1em 0;
+}
+
 /* Type styling */
 .md-typeset kbd {
   border-radius: 1em;

--- a/material-overrides/root-index-page.html
+++ b/material-overrides/root-index-page.html
@@ -1,0 +1,38 @@
+{% extends "main.html" %}
+
+{% block styles %}
+	{{ super() }}
+  <link rel="stylesheet" href="{{ 'assets/stylesheets/index-page.css' | url }}">
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <!-- <div class="disclaimer"></div> -->
+{% endblock %}
+
+{% block site_nav %}
+  {% if nav %}
+    {% if page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+    {% endif %}
+    <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" {{ hidden }}>
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner main-page-sidebar">
+          {% include "partials/nav.html" %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  {% if "toc.integrate" not in features %}
+    {% if page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "toc" in page.meta.hide %}
+    {% endif %}
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc" {{ hidden }}>
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/toc.html" %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
This PR updates the following items:

- Makes cards for index pages more visible
- Updates the styling for the name of the root level section on the left navigation
- Implements a new template that doesn't automatically generate cards for the root section index pages