### PR TITLE
add cookie consent

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -1249,3 +1249,8 @@ label[for='__search']:hover {
 .mantine-1yrr1ry {
   font-size: 1.2em;
 }
+
+/* Cookie consent styling */
+.md-consent__inner {
+  box-shadow: 0 0 .2rem #ffffff1a,0 .2rem .4rem #fff3;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ plugins:
 extra:
   consent:
     title: Cookie consent
-    description: This site uses cookies to deliver its service and to analyse traffic. By browsing this site, you accept the <a href="https://wormhole.com/pages/data-protection-and-privacy-policy" target="_blank" rel="noopener">privacy policy</a>.
+    description: This site uses cookies to deliver its service and to analyze traffic. By browsing this site, you accept the <a href="https://wormhole.com/pages/data-protection-and-privacy-policy" target="_blank" rel="noopener">privacy policy</a>.
     actions:
       - accept
       - reject

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,12 @@ plugins:
       include_yaml:
         - wormhole-docs/variables.yml
 extra:
+  consent:
+    title: Cookie consent
+    description: This site uses cookies to deliver its service and to analyse traffic. By browsing this site, you accept the <a href="https://wormhole.com/pages/data-protection-and-privacy-policy" target="_blank" rel="noopener">privacy policy</a>.
+    actions:
+      - accept
+      - reject
   generator: false
   social:
     - icon: fontawesome/brands/x-twitter


### PR DESCRIPTION
This PR adds the cookie consent form to the docs site. It just uses the default styling provided by Material for Mkdocs