### PR TITLE
Eshaben/styling feedback

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -12,7 +12,7 @@ h3 {
 .hero {
   display: flex;
   text-align: left;
-  padding: 0 0 1em 0;
+  padding: 0;
   align-items: center;
   min-height: 50em;
   margin-top: -8em;
@@ -43,7 +43,7 @@ h3 {
 
 .hero p {
   font-size: var(--body-l-size);
-  margin: 3em 0 3.5em;
+  margin: 4em 0 6em;
 }
 
 .button-wrapper {
@@ -185,6 +185,11 @@ h3 {
 
   .hero {
     margin-top: -5em;
+  }
+
+  .hero p {
+    font-size: var(--body-l-size);
+    margin: 3em 0;
   }
 
   .feature p {

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -956,6 +956,8 @@ pre .md-clipboard {
 .md-typeset .grid>.card {
   background-color: var(--grey);
   border: var(--md-border-width) solid var(--md-border-color);
+  display: flex;
+  flex-direction: column;
 }
 
 .md-typeset .grid.cards>ol>li:focus-within,
@@ -965,6 +967,12 @@ pre .md-clipboard {
 .md-typeset .grid>.card:focus-within,
 .md-typeset .grid>.card:hover {
   border: var(--md-border-width) solid var(--md-border-color);
+}
+
+.md-typeset .grid.cards>ol>li>:last-child,
+.md-typeset .grid.cards>ul>li>:last-child,
+.md-typeset .grid>.card>:last-child {
+  margin-top: auto;
 }
 
 .md-typeset .grid.half {

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -972,6 +972,10 @@ pre .md-clipboard {
   margin: 1em 1.4em 1em 0;
 }
 
+.md-typeset .grid.cards .twemoji.lg.middle svg {
+  margin-right: .5em;
+}
+
 /* Type styling */
 .md-typeset kbd {
   border-radius: 1em;


### PR DESCRIPTION
This PR applies feedback from the issues tracker spreadsheet:

- Remove a bit of the unnecessary vertical space in main landing page - the video is what takes up more space than the text and the buttons fill. So this just spreads out the text and the buttons a little bit to make it seem like there is less vertical space between the header elements the three cards below it

   <img width="1789" alt="Screenshot 2024-09-09 at 1 11 09 PM" src="https://github.com/user-attachments/assets/fc9c1467-61bf-4dde-b4db-9f150df6df0e">

- adds spacing between icons and card titles on index pages

    <img width="430" alt="Screenshot 2024-09-09 at 1 11 22 PM" src="https://github.com/user-attachments/assets/34255fd9-329c-4348-beb8-ea3d8e12a562">
