### PR TITLE
add interface and child admonition styling

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -14,8 +14,10 @@
   --light-transparent-90: rgba(255, 255, 255, 0.9);
   --light-transparent-60: rgba(255, 255, 255, 0.6);
   --light-transparent-40: rgba(255, 255, 255, 0.4);
+  --light-transparent-20: rgba(255, 255, 255, 0.2);
   --light-transparent-12: rgba(255, 255, 255, 0.12);
   --light-transparent-10: rgba(255, 255, 255, 0.1);
+  --light-transparent-07: rgba(255, 255, 255, 0.07);
   --plum: #c1bbf6;
   --plum-transparent-70: rgba(193, 187, 246, 0.7);
   --plum-transparent-50: rgba(193, 187, 246, 0.5);
@@ -686,8 +688,15 @@ pre .md-clipboard {
 
 .md-typeset .tabbed-block p,
 .md-typeset .tabbed-block ul,
-.md-typeset .tabbed-block ol {
+.md-typeset .tabbed-block ol,
+.md-typeset .tabbed-block p~div,
+.md-typeset .tabbed-block details {
   margin: 1em;
+}
+
+.md-typeset .tabbed-block ul p,
+.md-typeset .tabbed-block ol p {
+  margin: 0;
 }
 
 /* Document date styling */
@@ -1253,4 +1262,52 @@ label[for='__search']:hover {
 /* Cookie consent styling */
 .md-consent__inner {
   box-shadow: 0 0 .2rem #ffffff1a,0 .2rem .4rem #fff3;
+}
+
+/* Interface admonition styling */
+details.interface>summary::before {
+  display: none;
+}
+
+.md-typeset details.interface {
+  border: 1px solid var(--light-transparent-20);
+  box-shadow: none;
+  width: auto;
+}
+
+[dir=ltr] .md-typeset details.interface>summary {
+  padding: 1em 0 1em 1em;
+  background-color: var(--light-transparent-07);
+}
+
+.md-typeset details.interface>summary:after {
+  top: auto;
+}
+
+/* Child admonition styling */
+details.child summary::before {
+  display: none;
+}
+
+details.child {
+  width: fit-content;
+}
+
+[dir=ltr] .md-typeset details.child summary {
+  width: fit-content;
+  padding-left: 1em;
+}
+
+[dir=ltr] .md-typeset details.child[open] {
+  width: auto;
+}
+
+.md-typeset details.child summary {
+  background-color: unset;
+}
+
+.md-typeset details.child {
+  width: fit-content;
+  border: 1px solid var(--light-transparent-20);
+  box-shadow: none;
 }


### PR DESCRIPTION
This PR adds styling so we can use interface and child admonitions. It results in the following look, where the parameters dropdown is an interface admonition and the type dropdowns are child admonitions:

<img width="739" alt="Screenshot 2024-09-11 at 9 37 23 AM" src="https://github.com/user-attachments/assets/e46eb891-d478-4c73-b5f4-0ed5a999ea3c">
