### PR TITLE
update klaytn to kaia

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -10,13 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.10.18",
-        "@wormhole-foundation/sdk": "0.10.7",
-        "@wormhole-foundation/sdk-icons": "0.10.7",
+        "@wormhole-foundation/sdk": "0.10.9",
+        "@wormhole-foundation/sdk-icons": "0.10.9",
         "sharp": "^0.33.5",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
-        "@types/node": "^22.5.5",
+        "@types/node": "^22.7.4",
         "markdown-link-check": "^3.12.2",
         "typescript": "^5.6.2"
       }
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.12.14",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.14.tgz",
-      "integrity": "sha512-0FoG2EkXxTY+++dKggmBkwY/skAE5dW2yqt4abHF0zrbCId4WreoFfhoTQT82FeD6gbkYe5FGrcn1x9SjnO77g==",
+      "version": "1.12.15",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.15.tgz",
+      "integrity": "sha512-3DHkAu4JCp+T7U4n/9VoXe8pfGjPnDHXKupCFULkBINK8j4fk6umqseLuQaZLcz6DG5JayGZ3zdhUxdUVlumdA==",
       "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
@@ -2822,9 +2822,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2870,48 +2870,48 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.10.7.tgz",
-      "integrity": "sha512-vQPvhcKQpGfo+zT5OzXuXDRbcuHPbbD/2oQC01zLpJZ8E8z0rCGmLdZJ220liGFjgvn0/XXlAyz6MiL3DYgMlw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.10.9.tgz",
+      "integrity": "sha512-k9ODDvY3whX6VoO+QUtYtnX0vAzUR+E5ytuMMajDVPyZvpKsuDRx3QyQiQ26vcXLJF88zaHaNxrbqiAAjT+J0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.10.7",
-        "@wormhole-foundation/sdk-algorand-core": "0.10.7",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.10.7",
-        "@wormhole-foundation/sdk-aptos": "0.10.7",
-        "@wormhole-foundation/sdk-aptos-core": "0.10.7",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.10.7",
-        "@wormhole-foundation/sdk-base": "0.10.7",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.10.7",
-        "@wormhole-foundation/sdk-definitions": "0.10.7",
-        "@wormhole-foundation/sdk-evm": "0.10.7",
-        "@wormhole-foundation/sdk-evm-cctp": "0.10.7",
-        "@wormhole-foundation/sdk-evm-core": "0.10.7",
-        "@wormhole-foundation/sdk-evm-portico": "0.10.7",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.7",
-        "@wormhole-foundation/sdk-solana": "0.10.7",
-        "@wormhole-foundation/sdk-solana-cctp": "0.10.7",
-        "@wormhole-foundation/sdk-solana-core": "0.10.7",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.10.7",
-        "@wormhole-foundation/sdk-sui": "0.10.7",
-        "@wormhole-foundation/sdk-sui-core": "0.10.7",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.10.7"
+        "@wormhole-foundation/sdk-algorand": "0.10.9",
+        "@wormhole-foundation/sdk-algorand-core": "0.10.9",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.10.9",
+        "@wormhole-foundation/sdk-aptos": "0.10.9",
+        "@wormhole-foundation/sdk-aptos-core": "0.10.9",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.10.9",
+        "@wormhole-foundation/sdk-base": "0.10.9",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.10.9",
+        "@wormhole-foundation/sdk-definitions": "0.10.9",
+        "@wormhole-foundation/sdk-evm": "0.10.9",
+        "@wormhole-foundation/sdk-evm-cctp": "0.10.9",
+        "@wormhole-foundation/sdk-evm-core": "0.10.9",
+        "@wormhole-foundation/sdk-evm-portico": "0.10.9",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.9",
+        "@wormhole-foundation/sdk-solana": "0.10.9",
+        "@wormhole-foundation/sdk-solana-cctp": "0.10.9",
+        "@wormhole-foundation/sdk-solana-core": "0.10.9",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.10.9",
+        "@wormhole-foundation/sdk-sui": "0.10.9",
+        "@wormhole-foundation/sdk-sui-core": "0.10.9",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.10.7.tgz",
-      "integrity": "sha512-kZShoIpqJytvJfEDTWSE8XadC4+m4bHrmC9uJ6JuabvFhcGoIug14NiZJ1QiPpN2l5rpDjSX3DqwwW2EdxV8xA==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.10.9.tgz",
+      "integrity": "sha512-taKBxnvxfK2V7AFRr+ItU7+g3Uw63v/urPLMNk3/a7+C7+S5XJXbAO5iJq5nnpSdPAX8fnsgwCnWDjPTWsMClA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2919,39 +2919,39 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.10.7.tgz",
-      "integrity": "sha512-nRvVyTkh2SQoEoFWQd2dmIO9RW83S9+7NqVeK35hZjVzFA9d0yfESzCP/Tbm/JjnCNmkzw759bHWE6kq8S7QNg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.10.9.tgz",
+      "integrity": "sha512-RZcvWeKFwANi6snYXL53xeuNL0HNEMxL8YUh4ARdUVRfLJ8IGFWJZwfJCpLRU+Ny2c3XMezf1B+OUaEr50Eagw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.10.7",
-        "@wormhole-foundation/sdk-connect": "0.10.7"
+        "@wormhole-foundation/sdk-algorand": "0.10.9",
+        "@wormhole-foundation/sdk-connect": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-5UdeuFLD8yxvymXeHSUhlV/C4A4Q47BgES/ANHHiLwlDkN6hnFSK4Dh6xCNX6TLHkjk9R6zXp9xUUPWTs2KRXA==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-Ga/eUHNH33acHJO5CZJHwsEh/aNbBJhHhFnp/VNfwFrj4kryvwG5l58q6NazztDytVLQG/hNj9S/vMBlcKLDxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.10.7",
-        "@wormhole-foundation/sdk-algorand-core": "0.10.7",
-        "@wormhole-foundation/sdk-connect": "0.10.7"
+        "@wormhole-foundation/sdk-algorand": "0.10.9",
+        "@wormhole-foundation/sdk-algorand-core": "0.10.9",
+        "@wormhole-foundation/sdk-connect": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.10.7.tgz",
-      "integrity": "sha512-KZ6JlWHbmWOvdKh2fMuIuUDVRkZRl2zmkHD4OoA49dawWSm6B0NDM+mnqH0hVd57Iv417fKpFlFptQSM4qJA6g==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.10.9.tgz",
+      "integrity": "sha512-dPD2SYVFwRbFn1zZSsOfFm0knnzUn/9Lv97dLbebjfusEHfqVz7rdvPDR+nTvk7A8i7ex25HLs0VRK146Nr59A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -2959,26 +2959,26 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.10.7.tgz",
-      "integrity": "sha512-ck8KW5xE8YPB34FPP3plkQOPeoWwSfiO8OLArYnlHrFPJX1QAoAc8C1Ktj+xPmdHQG53H1mdxtn2raWNYABknw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.10.9.tgz",
+      "integrity": "sha512-RE1jbEXBy08swG2/b73nYL8kFlLu07NybJdTRgxRIoKB7Vkwu5/9SeV9SRfHWz3DIEzsSseT2+0061TDIHtdJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.10.7",
-        "@wormhole-foundation/sdk-connect": "0.10.7"
+        "@wormhole-foundation/sdk-aptos": "0.10.9",
+        "@wormhole-foundation/sdk-connect": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-592QMwVPxyDF1gGCVn+dz2PPz+53WQb/6XrPMh+b1kwaICdZnjdJumZ103BiJ3Lh7xwEQfTEoSLF8XhFusgsAg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-hFI6Qug2O2z6TnSE69a3L4wa2TuC5HGwzVrSNMY6py9E8Fevs4pm35jNqUaSuE69SZ2WqmbsvDnTuqwCUCsKeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.10.7",
-        "@wormhole-foundation/sdk-connect": "0.10.7"
+        "@wormhole-foundation/sdk-aptos": "0.10.9",
+        "@wormhole-foundation/sdk-connect": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -3000,6 +3000,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
       "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
+      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/aptos-client": "^0.1.0",
@@ -3020,22 +3021,22 @@
       "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.10.7.tgz",
-      "integrity": "sha512-2UEy0BREBT8mtJFzkTx8zsBtw8s1LppHQ8r+1CPT1McMLPYcHSVRAg8OBOYsdhx2N2iyvMjJgGIeE1I0Y6c8Vg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.10.9.tgz",
+      "integrity": "sha512-E56Z7FK1swrHvBvDOgWZBLDcyijpGB27dw10ZAZgesHksTBCIS4ehJY9b2qulo19R3fxRW/reKYzAmjxkpI+sg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.10.7.tgz",
-      "integrity": "sha512-NzJXVG4auD6JuMsysLQUGiK4NVJ8p1me59Rjys87I+wBRszLfe6gRy0/tKhXT/ArjXzYPKNRsgymFi7mYXEe8w==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.10.9.tgz",
+      "integrity": "sha512-UCneSFMDho3p3rUFoxpDV+9zutJWcQJJ78RLLpjya0EivNy2AMTFWbP0sQdx+3kHw0MIJM/JtsUoUhPZZKeD/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.10.7",
-        "@wormhole-foundation/sdk-definitions": "0.10.7",
+        "@wormhole-foundation/sdk-base": "0.10.9",
+        "@wormhole-foundation/sdk-definitions": "0.10.9",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3054,16 +3055,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.10.7.tgz",
-      "integrity": "sha512-AAstteWWqyw+k8dA70+/XuWx93oAdnWiCJDMWedTU9CsxKKYnY8zWydZtuv0Qnlm97n7bIQ1SGwbwFYdT+397w==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.10.9.tgz",
+      "integrity": "sha512-GeAvbYzvOMYvZM5dN+6EHbOD5vtTxQYk6tesXPwbi/d6Cm5kMNXCjzCu8pUc7Wxhw4vHd90/eaQN6eADA/j1vA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3071,16 +3072,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.10.7.tgz",
-      "integrity": "sha512-atwZ7bGJxlz/rPY8GiPA+mRN+M78MEYDnIKRR5ibaRCeLgA3FZXmBRGauPmvSQJqydi5kAZoIkHXQzQIhDCaNA==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.10.9.tgz",
+      "integrity": "sha512-2EiDSIOod+LaQFndLSS4cyNaVprNHoXrH1biQZUnZiDfB9WdhxtuFA72pVDqpc9knu9FAHAHyEtfsoKLOsvj7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -3474,17 +3475,17 @@
       "license": "0BSD"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.10.7.tgz",
-      "integrity": "sha512-ArNRP/tBnSwMnk9nkhB+mvFpgMh/IA1ameVu/qZ9/Z30YjgbyHM+WZr51Pm0ar5KIEe4ykjr6m4gTDq/I/fmZg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.10.9.tgz",
+      "integrity": "sha512-f9L2VJb46p7UhwP1pvSpCuT57BUCwCeRrttesg+CwUkkk4pTlP1Bhk7XduHcOZrAdpyVrpIkgEDJSn2DB3OjPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.10.9",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3879,15 +3880,15 @@
       "license": "0BSD"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-69wjM7gHOjY9j1vcVuafqCl18F0j3Jl5UZ+dZ8cPh+WlWAIGQW8YYi7r4Fp5jAKNRXSqszQ3jADxShS9KUTDPA==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-+wr4Ndl4swNt62ZvHGPFSCCiDKqcyLeFTGjz8+LJdgqk7/3eAkfqfXXHJc//TJ0qgB268iddYCFAGlbZRZtbng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-cosmwasm": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-cosmwasm": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -4668,13 +4669,13 @@
       "license": "0BSD"
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.10.7.tgz",
-      "integrity": "sha512-9FUVqxbp91TjWofp2/3C/wCYlkdkt0ceM6Copc0zVDvD7sW8RpKVceWCttTZs843aKkRnGAkM+zLdT8kW/UUSw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.10.9.tgz",
+      "integrity": "sha512-9lbMpvcaBL9a2eoyfJ5gauFREO0hqYw+Nplc3L6qzckB/2Sc0nE0vYDRyL+OwaRT4BUffmWOaUukBEDqbc1sGQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.10.7"
+        "@wormhole-foundation/sdk-base": "0.10.9"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/curves": {
@@ -4705,12 +4706,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.10.7.tgz",
-      "integrity": "sha512-SLZBlvllNXBiJAI0n5GTFyRwKG19CBT/i/hFbzH/xx0JJ72J0HpUklm02fyEe4I/Qg2pRoJvN65Z4/YdYLcMnw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.10.9.tgz",
+      "integrity": "sha512-AM66hZHMAvggv9GwOdyep5AOT0M6JTJ415c+ksmdSw7egyVGwAXWl0khfJE1BHQDDAIsmJaTtPINQwdaki+4Yw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4718,13 +4719,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.10.7.tgz",
-      "integrity": "sha512-Mx3hP34mAx4QUScOl5dtcE5G4803H6ySUyLYAmHB3pw5IDKeXCFRlMxWk79EQE7m6Bf6AzAO6mEuW5THEfzc4g==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.10.9.tgz",
+      "integrity": "sha512-iaPbBjxwJieuUObmAgB+XLZ4Cp4USUKC/mMyOjUmtovukifQcMaTkzWXNGsn+sEPS7hAwd1XWxOk9NWeXc0QAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-evm": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-evm": "0.10.9",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4823,13 +4824,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.10.7.tgz",
-      "integrity": "sha512-5qkSvORF9dVYMPTTfsBWghC3NcIDnMryomTyCPnhH/uFL5E4GnV9Nqs6WZ18HE98nyIM0+JHmh/Yu1RHWxu2mw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.10.9.tgz",
+      "integrity": "sha512-XdQfJh39YJqtpn/guU2NBDHIFOj1tYxOk3h7zZG0vsH3D0RcFOinUboPrLkDoVlJ57TqQt0UrV2ISvQhWEZT6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-evm": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-evm": "0.10.9",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4928,15 +4929,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.10.7.tgz",
-      "integrity": "sha512-ECdSytF4C3Rd4pUa4BR47bvMdC89SW+9kKAU7l0TAWfEdh9sWgX79Xk/Zv1h4BhvzwZQP3tKxQblK1rEIY4loA==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.10.9.tgz",
+      "integrity": "sha512-JNAJ7DmT2GquKFJ+JWYZ+Ofwehw5CUOnteF029A1SmxiVMawfkB9lpRBuUkPBznkqLXBktPhN95CmmHPe0+Xnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-evm": "0.10.7",
-        "@wormhole-foundation/sdk-evm-core": "0.10.7",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-evm": "0.10.9",
+        "@wormhole-foundation/sdk-evm-core": "0.10.9",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.10.9",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -5035,14 +5036,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-cmCUmAjCNaaIo/2k5Ct5g0jW0Q9zTYVo+CocJrHa84rvghgwGYT/Ji8hUKZiMdNW2Sf9eTU/t6XozpEAY4/nSw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-Dn0J3i5hgnHy9oYD5fJAoypPt7GzoSNMstRdqqEWaRBIE1qEwbMMGuA100AfOWy0QexZCCj0S3lt1ULtqWTXyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-evm": "0.10.7",
-        "@wormhole-foundation/sdk-evm-core": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-evm": "0.10.9",
+        "@wormhole-foundation/sdk-evm-core": "0.10.9",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -5232,25 +5233,25 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-0.10.7.tgz",
-      "integrity": "sha512-3OWCVMYm3N7+Y/ATmIYqWLSYp5MHShwtnSBKgKVW7g5H/+Ned1kJQBKgpcMINpBZ0MhDRoDHbts/kBn5V3xqsw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-0.10.9.tgz",
+      "integrity": "sha512-Kg36yCSme+/S+ie+FTNIBBnhE89z2lOsse4fcjSsvyAhBxTd2oxkkwUGHCxquuEc6xLRAqRzbv6IboYaQawakA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.10.7"
+        "@wormhole-foundation/sdk-base": "0.10.9"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.10.7.tgz",
-      "integrity": "sha512-ic3ktViBTULxpslrtxdyHh+nWFPmssKkeR1rAYaL3szBOi16N5xtTbhFsEMU+f1MQTbhn+TrEoftxuMJny6dOw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.10.9.tgz",
+      "integrity": "sha512-+dW7jBhTb8sgEcJF7Y2BkfM2QR7OaiL/6m25ungkDt7wFuPIIVGi4NM0Szngg+YyMs910PYdR1lcXd3Ijl/Nrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
+        "@wormhole-foundation/sdk-connect": "0.10.9",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -5258,32 +5259,32 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.10.7.tgz",
-      "integrity": "sha512-HPfNYuCRxGchzb6pqu6vyRS8+yPD1vddI+exs2KGsH3thk+xFOn+X7OUSufNoU1ZZyNSOpX9SNYQPb6Qw+qenQ==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.10.9.tgz",
+      "integrity": "sha512-nlHiqVxh2YgAsir3+O2y1sSlmgZfgkeM/lkxyvfWdVNj1YKNw44t1S4TO1N6eONHbq2iyMv7JELDbWwDnqgq2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-solana": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-solana": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.10.7.tgz",
-      "integrity": "sha512-9Xj8vWC8yO09HZlvfYr2t50YTBt37ZLg5KeiuWivbC++Ra8rdEDlkKOV4z30M8ahRAhcbgETHguoRFSHWdD76Q==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.10.9.tgz",
+      "integrity": "sha512-M+ZZpiZRwTTlm+bn1ZPYecUlcDI+OUwgX8bgwmgcQSADxXJkYtOFPsAB2R8eOcAmQirhkMK4Mjv//+IHrfaTBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-solana": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-solana": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -5306,17 +5307,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-CpSTrNCcE6tRCOus+52jYTvMWFk/3V3pYTScQelEtM+DisJdhRxReUoU1KfpHoDjJ0YZshyArvOgDYzVVVKq6g==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-8TbwzgKNQ9+wx37mkjEKb5oWcSJGZCmR/2P0NyxHEwuG2lTe7XkHKV6e8JmTZLAy/6i8Xmwc+y5e1gLgFaeHLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-solana": "0.10.7",
-        "@wormhole-foundation/sdk-solana-core": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-solana": "0.10.9",
+        "@wormhole-foundation/sdk-solana-core": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -5338,68 +5339,28 @@
         "@solana/web3.js": "^1.68.0"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-solana/node_modules/rpc-websockets": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "uuid": "^8.3.2",
-        "ws": "^8.5.0"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/kozjak"
-      },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-solana/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.10.7.tgz",
-      "integrity": "sha512-OMdg8pHj8sVb7iLws7CRQufiqUuvtNr4jerjEcEfZiXBuzpTjU87feNksf5Bs6ntqVbiC1upbF3GGHNlkd1jaQ==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.10.9.tgz",
+      "integrity": "sha512-CVKiaYMzFW7R/1nqU3WACWa/5cD3+bv8dKoBHk99vJMJe28QgWSR/Li0XLwSEmv+AweRRI3WomgF3xj2j3qbCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.10.7.tgz",
-      "integrity": "sha512-vHSLbs0y6sVGDKoZT/VoGxzrfe3SoU1obQ1aQMx3GbBs0CVKIy0U+vJM44SSUWbv6i6XfnexF633d1uADs1JUg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.10.9.tgz",
+      "integrity": "sha512-OY1dYq57zzbwQzTS3fcPQB9myluItr+XoEIbzUvBpWL6BvOZfdxhqYVudZ4y13N4lQvs/hKMk7c/rpOUH6LUaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-sui": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-sui": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -5418,6 +5379,7 @@
       "version": "0.50.1",
       "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
       "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -5453,15 +5415,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.10.7.tgz",
-      "integrity": "sha512-lWNqizlR4keEYd1iymSrUhXs5+Ep/aZ04WjxlLPkwMfrGsanxgvl0ZTvrDnGYozOOJ7QpRTIp8qBeGK2vTTnEQ==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.10.9.tgz",
+      "integrity": "sha512-33VMlJgFDyytODEN5IamGzLUXj9usWDqY5+Btpo2Dt4p29NH7lw7YiNYyZLpZoV4by2xSZ0oJ9U5anhWxNIx6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.10.7",
-        "@wormhole-foundation/sdk-sui": "0.10.7",
-        "@wormhole-foundation/sdk-sui-core": "0.10.7"
+        "@wormhole-foundation/sdk-connect": "0.10.9",
+        "@wormhole-foundation/sdk-sui": "0.10.9",
+        "@wormhole-foundation/sdk-sui-core": "0.10.9"
       },
       "engines": {
         "node": ">=16"
@@ -5480,6 +5442,7 @@
       "version": "0.50.1",
       "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
       "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -5527,6 +5490,7 @@
       "version": "0.50.1",
       "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
       "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -7273,9 +7237,9 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.7.tgz",
-      "integrity": "sha512-ixqMvH5jRs5wxe5liNoaG1TA9NfA+kAz8QzfT0xrzcKARJOVC7MednVhxyhY1RDgZH8mNfChK3ti8cIcd9cuuw==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.9.tgz",
+      "integrity": "sha512-hW6SWLfkRUh/xDYSAb9Ps+Eb3kp7LyZ9GGrWUyfy3d8rG2bIAj+DvyZwxy4HyQHyjZLVJU1doJhvXrYvVez+xw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
@@ -8861,11 +8825,11 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.1.tgz",
-      "integrity": "sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
+      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
+      "license": "LGPL-3.0-only",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
         "uuid": "^8.3.2",
         "ws": "^8.5.0"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,14 +14,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^22.7.4",
     "markdown-link-check": "^3.12.2",
     "typescript": "^5.6.2"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.10.18",
-    "@wormhole-foundation/sdk": "0.10.7",
-    "@wormhole-foundation/sdk-icons": "0.10.7",
+    "@wormhole-foundation/sdk": "0.10.9",
+    "@wormhole-foundation/sdk-icons": "0.10.9",
     "sharp": "^0.33.5",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/card.ts
+++ b/scripts/src/card.ts
@@ -20,7 +20,7 @@ export function chainCard(
 
 <strong>${title}</strong>
 <br><br>
-<a href="${link}"><img class="no-lightbox" src="${icon}" alt="${title}" style="width:90px; height:auto;"></a>
+<a href="${link}"><img class="no-lightbox" src="${icon}" alt="${title}" style="max-width:90px; max-height:90px;"></a>
 
 </div>`;
 }

--- a/scripts/src/chains/klaytn.json
+++ b/scripts/src/chains/klaytn.json
@@ -1,32 +1,32 @@
 {
-  "title": "Klaytn",
-  "homepage": "https://klaytn.foundation/",
+  "title": "Kaia",
+  "homepage": "https://kaia.io/",
   "contractSource": "ethereum/contracts/bridge/Bridge.sol",
   "mainnet":{
     "name":"Mainnet",
     "id":"8217"
   },
   "testnet":{
-    "name":"Baobab",
+    "name":"Kairos",
     "id":"1001"
   },
   "explorer": [
     {
-      "url": "https://www.klaytnfinder.io/",
-      "description": "Klaytnfinder"
+      "url": "https://kaiascan.io/",
+      "description": "Kaiascan"
     },
     {
-      "url": "https://scope.klaytn.com/",
-      "description": "Klaytnscope"
+      "url": "https://kaiascope.com/",
+      "description": "Kaiascope"
     }
   ],
   "developer": [
     {
-      "url": "https://docs.klaytn.foundation/",
+      "url": "https://docs.kaia.io/",
       "description": "Developer docs"
     },
     {
-      "url": "https://baobab.wallet.klaytn.foundation/faucet",
+      "url": "https://faucet.kaia.io",
       "description": "Faucet"
     }
   ],


### PR DESCRIPTION
This PR updates Klaytn to Kaia. For more info: https://docs.kaia.io/misc/kaia-transition/faq-chain-transition/
It also updates the CSS to be more flexible; more CSS changes need to be applied soon to make it more semantically correct.

⚠️ Note: The file name under `src/chains` needs to remain as Klaytn until the SDK gets updated. I'm waiting on a response from the devrel engineer from Klaytn before proceeding with any changes to the SDK. But for now, we can at least do this update.