### PR TITLE
Publish c5de17f and the cosmos redirects

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,8 @@ plugins:
       redirect_maps:
         # Redirects will go here as pages get moved around in the following format:
         # old-page.md: new-page.md
+        build/start-building/supported-networks/cosmos/gateway.md: build/start-building/supported-networks/cosmos.md
+        build/start-building/supported-networks/cosmos/cosmos.md: build/start-building/supported-networks/cosmos.md
   - macros:
       include_yaml:
         - wormhole-docs/variables.yml


### PR DESCRIPTION
This PR removes the gateway onboarding page: https://github.com/wormhole-foundation/wormhole-docs/pull/128
and updates the redirects: https://github.com/papermoonio/wormhole-mkdocs/pull/74