### PR TITLE
publish 55f5bf3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,8 @@ plugins:
         # old-page.md: new-page.md
         build/start-building/supported-networks/cosmos/gateway.md: build/start-building/supported-networks/cosmos.md
         build/start-building/supported-networks/cosmos/cosmos.md: build/start-building/supported-networks/cosmos.md
+        build/contract-integrations/gateway.md: build/start-building/supported-networks/cosmos.md
+        learn/messaging/gateway.md: learn/messaging/index.md
   - macros:
       include_yaml:
         - wormhole-docs/variables.yml


### PR DESCRIPTION
This PR includes the following `wormhole-docs` PRs:

- https://github.com/wormhole-foundation/wormhole-docs/pull/127
- https://github.com/wormhole-foundation/wormhole-docs/pull/129
- https://github.com/wormhole-foundation/wormhole-docs/pull/130
- https://github.com/wormhole-foundation/wormhole-docs/pull/131
- https://github.com/wormhole-foundation/wormhole-docs/pull/133

It also includes the addition of redirects for the Gateway pages, which was completed in PR #79.

---

⚠️ Note: PR #80 needs to be merged in before this can be approved and merged.