### PR TITLE
fix styling of cookbook widget for safari

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -1348,6 +1348,11 @@ label[for='__search']:hover {
   margin: 0;
 }
 
+.cookbook-container {
+  /* Specifically needed for Safari */
+  width: max-content;
+}
+
 /* Cookie consent styling */
 .md-consent__inner {
   box-shadow: 0 0 .2rem #ffffff1a,0 .2rem .4rem #fff3;


### PR DESCRIPTION
The width of the widget needed to be adjusted so it rendered properly on Safari specifically.

Before:
<img width="266" alt="Screenshot 2024-11-07 at 9 21 50 PM" src="https://github.com/user-attachments/assets/89e53e0a-37a5-4b5d-b25b-c90bd302d5be">

After:
<img width="246" alt="Screenshot 2024-11-07 at 9 21 32 PM" src="https://github.com/user-attachments/assets/d256db31-e676-491e-82f7-2282da486e07">
