### PR TITLE
Bump sdk version to 1.3.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "1.2.0",
+        "@wormhole-foundation/sdk": "1.3.0",
         "sharp": "^0.33.5",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
-        "@types/node": "^22.10.1",
+        "@types/node": "^22.10.2",
         "markdown-link-check": "^3.13.6",
         "typescript": "^5.7.2"
       }
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.2.tgz",
-      "integrity": "sha512-dkacsdMgVsrrQhLpN4JqZTIEfnNsPVwny+4vccSRqheWZElzUz1Xi0h39p2+TieS1f+wwvyzwpoJEV57vwzT9Q==",
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.4.tgz",
+      "integrity": "sha512-S/eC9jxEW9Jg1BjD6AZonE1fHxYuvC3gFHop8FRQkUdeK63MmBD5r0DOrN2WlJbwha1MSD6A97OwXwjaujEQpA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
-      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -172,43 +172,14 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/@confio/ics23": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
       "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "protobufjs": "^6.8.8"
-      }
-    },
-    "node_modules/@confio/ics23/node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/@coral-xyz/anchor": {
@@ -236,7 +207,7 @@
         "node": ">=11"
       }
     },
-    "node_modules/@coral-xyz/anchor/node_modules/@coral-xyz/borsh": {
+    "node_modules/@coral-xyz/borsh": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
       "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
@@ -252,23 +223,17 @@
         "@solana/web3.js": "^1.68.0"
       }
     },
-    "node_modules/@coral-xyz/anchor/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+    "node_modules/@cosmjs/amino": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
+      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4"
       }
-    },
-    "node_modules/@coral-xyz/anchor/node_modules/superstruct": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
-      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
-      "license": "MIT"
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
       "version": "0.32.4",
@@ -288,19 +253,7 @@
         "pako": "^2.0.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/crypto": {
+    "node_modules/@cosmjs/crypto": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
       "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
@@ -315,7 +268,7 @@
         "libsodium-wrappers-sumo": "^0.7.11"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/encoding": {
+    "node_modules/@cosmjs/encoding": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
       "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
@@ -326,7 +279,7 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/json-rpc": {
+    "node_modules/@cosmjs/json-rpc": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
       "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
@@ -336,7 +289,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
+    "node_modules/@cosmjs/math": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
       "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
@@ -345,7 +298,7 @@
         "bn.js": "^5.2.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/proto-signing": {
+    "node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
       "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
@@ -359,7 +312,7 @@
         "cosmjs-types": "^0.9.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/socket": {
+    "node_modules/@cosmjs/socket": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
       "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
@@ -371,7 +324,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stargate": {
+    "node_modules/@cosmjs/stargate": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
       "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
@@ -389,7 +342,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stream": {
+    "node_modules/@cosmjs/stream": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
       "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
@@ -398,7 +351,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/tendermint-rpc": {
+    "node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
       "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
@@ -416,33 +369,10 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/utils": {
+    "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
       "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/cosmjs-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/runtime": {
@@ -469,6 +399,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -486,7 +417,8 @@
           "type": "individual",
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/@gql.tada/cli-utils": {
       "version": "1.6.3",
@@ -531,6 +463,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -896,6 +829,48 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@injectivelabs/core-proto-ts": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
+      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@injectivelabs/core-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@injectivelabs/exceptions": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.33.tgz",
@@ -912,6 +887,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
       "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -923,6 +899,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.0.2.tgz",
       "integrity": "sha512-rpyhXLiGY/UMs6v6YmgWHJHiO9l0AgDyVNv+jcutNVt4tQrmNvnpvz2wCAGOFtq5LuX/E9ChtTVpk3gWGqXcGA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
@@ -931,8 +908,105 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-react-native-transport/-/grpc-web-react-native-transport-0.0.2.tgz",
       "integrity": "sha512-mk+aukQXnYNgPsPnu3KBi+FD0ZHQpazIlaBZ2jNZG7QAVmxTWtv3R66Zoq99Wx2dnE946NsZBYAoa0K5oSjnow==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
+      }
+    },
+    "node_modules/@injectivelabs/indexer-proto-ts": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@injectivelabs/indexer-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@injectivelabs/mito-proto-ts": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@injectivelabs/mito-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@injectivelabs/networks": {
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
+      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@injectivelabs/exceptions": "^1.14.33",
+        "@injectivelabs/ts-types": "^1.14.33",
+        "@injectivelabs/utils": "^1.14.33",
+        "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -946,6 +1020,84 @@
         "protobufjs": "^7.0.0",
         "rxjs": "^7.4.0"
       }
+    },
+    "node_modules/@injectivelabs/olp-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@injectivelabs/olp-proto-ts/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@injectivelabs/sdk-ts": {
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
+      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apollo/client": "^3.11.10",
+        "@cosmjs/amino": "^0.32.3",
+        "@cosmjs/proto-signing": "^0.32.3",
+        "@cosmjs/stargate": "^0.32.3",
+        "@ethersproject/bytes": "^5.7.0",
+        "@injectivelabs/core-proto-ts": "1.13.4",
+        "@injectivelabs/exceptions": "^1.14.33",
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
+        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
+        "@injectivelabs/indexer-proto-ts": "1.13.3",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.33",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.33",
+        "@injectivelabs/ts-types": "^1.14.33",
+        "@injectivelabs/utils": "^1.14.33",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@noble/curves": "^1.4.0",
+        "axios": "^1.6.4",
+        "bech32": "^2.0.0",
+        "bip39": "^3.0.4",
+        "cosmjs-types": "^0.9.0",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^6.5.1",
+        "google-protobuf": "^3.21.0",
+        "graphql": "^16.3.0",
+        "http-status-codes": "^2.2.0",
+        "js-sha3": "^0.8.0",
+        "jscrypto": "^1.0.3",
+        "keccak256": "^1.0.6",
+        "secp256k1": "^4.0.3",
+        "shx": "^0.3.2",
+        "snakecase-keys": "^5.4.1"
+      }
+    },
+    "node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
     },
     "node_modules/@injectivelabs/test-utils": {
       "version": "1.14.33",
@@ -964,19 +1116,16 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/test-utils/node_modules/@injectivelabs/networks": {
+    "node_modules/@injectivelabs/ts-types": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.33.tgz",
+      "integrity": "sha512-sJZzMNJtZFFZoPKZ91G09bxrZqQ5aS9omoTjQWy+7OxfiRAakzhsarTueX47hm6oTaN0XeBgD3wkMukkWUaobw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
         "shx": "^0.3.2"
       }
     },
-    "node_modules/@injectivelabs/test-utils/node_modules/@injectivelabs/utils": {
+    "node_modules/@injectivelabs/utils": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
       "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
@@ -992,25 +1141,6 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/test-utils/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@injectivelabs/ts-types": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.33.tgz",
-      "integrity": "sha512-sJZzMNJtZFFZoPKZ91G09bxrZqQ5aS9omoTjQWy+7OxfiRAakzhsarTueX47hm6oTaN0XeBgD3wkMukkWUaobw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "shx": "^0.3.2"
-      }
-    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -1020,6 +1150,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
       "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "license": "ISC",
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -1035,19 +1166,22 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -1058,23 +1192,103 @@
         "rlp": "^2.2.3"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
-      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+    "node_modules/@mysten/bcs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "1.3.1"
+        "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@mysten/bcs/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "license": "MIT"
+    },
+    "node_modules/@mysten/bcs/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@mysten/sui.js": {
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@mysten/bcs": "0.11.1",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/bip32": "^1.3.1",
+        "@scure/bip39": "^1.2.1",
+        "@suchipi/femver": "^1.0.0",
+        "bech32": "^2.0.0",
+        "gql.tada": "^1.2.0",
+        "graphql": "^16.8.1",
+        "superstruct": "^1.0.3",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mysten/sui.js/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/@mysten/sui.js/node_modules/superstruct": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1135,27 +1349,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1164,56 +1383,64 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
-      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.1.tgz",
-      "integrity": "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.1.0",
-        "@noble/hashes": "~1.3.1",
-        "@scure/base": "~1.1.0"
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1235,6 +1462,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
       "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -1246,6 +1474,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
       "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/web3.js": "^1.32.0",
@@ -1260,6 +1489,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
       "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -1273,9 +1503,9 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.95.8",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.8.tgz",
-      "integrity": "sha512-sBHzNh7dHMrmNS5xPD1d0Xa2QffW/RXaxu/OysRXBfwTp+LYqGGmMtCYYwrHPrN5rjAmJCsQRNAwv4FM0t3B6g==",
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -1295,37 +1525,10 @@
         "superstruct": "^2.0.2"
       }
     },
-    "node_modules/@solana/web3.js/node_modules/@noble/curves": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
-      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.5.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@solana/web3.js/node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1338,9 +1541,9 @@
       "license": "MIT"
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.2.tgz",
-      "integrity": "sha512-YzggvfItxMY3Lwuax5rC18inhbjJv9Py7JXRHxTIi94JOLrqBsSsUUc5bbl5W6c11tXhdfpDPK0KzBhoGe8jjw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.4.tgz",
+      "integrity": "sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -1393,16 +1596,23 @@
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
-      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
+      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -1424,9 +1634,10 @@
       "license": "MIT"
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1444,9 +1655,10 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1469,21 +1681,23 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1498,9 +1712,10 @@
       }
     },
     "node_modules/@types/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
+      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1515,53 +1730,55 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.2.0.tgz",
-      "integrity": "sha512-0kRNJmDEbF3TwaG0l5SXo/2g9hjXdIyfDz0LLRe26qZKx4BHcUV+uhhwy0l8mWNpLcxLmuPbHBbi3/E1F0ThlA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-I7cW+r9ss/wLl8VfU/pj7NxTlx4VJW2yLURXz8LpWkBO7hA0fzx8OWGTyxZrOIHH4JdCKF97in1jVbMwdsqTRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.2.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.2.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.2.0",
-        "@wormhole-foundation/sdk-aptos": "1.2.0",
-        "@wormhole-foundation/sdk-aptos-core": "1.2.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.2.0",
-        "@wormhole-foundation/sdk-base": "1.2.0",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.2.0",
-        "@wormhole-foundation/sdk-definitions": "1.2.0",
-        "@wormhole-foundation/sdk-evm": "1.2.0",
-        "@wormhole-foundation/sdk-evm-cctp": "1.2.0",
-        "@wormhole-foundation/sdk-evm-core": "1.2.0",
-        "@wormhole-foundation/sdk-evm-portico": "1.2.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.2.0",
-        "@wormhole-foundation/sdk-solana": "1.2.0",
-        "@wormhole-foundation/sdk-solana-cctp": "1.2.0",
-        "@wormhole-foundation/sdk-solana-core": "1.2.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.2.0",
-        "@wormhole-foundation/sdk-sui": "1.2.0",
-        "@wormhole-foundation/sdk-sui-core": "1.2.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.2.0"
+        "@wormhole-foundation/sdk-algorand": "1.3.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.3.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.3.0",
+        "@wormhole-foundation/sdk-aptos": "1.3.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.3.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.3.0",
+        "@wormhole-foundation/sdk-base": "1.3.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.3.0",
+        "@wormhole-foundation/sdk-definitions": "1.3.0",
+        "@wormhole-foundation/sdk-evm": "1.3.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.3.0",
+        "@wormhole-foundation/sdk-evm-core": "1.3.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.3.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.3.0",
+        "@wormhole-foundation/sdk-solana": "1.3.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.3.0",
+        "@wormhole-foundation/sdk-solana-core": "1.3.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.3.0",
+        "@wormhole-foundation/sdk-sui": "1.3.0",
+        "@wormhole-foundation/sdk-sui-cctp": "1.3.0",
+        "@wormhole-foundation/sdk-sui-core": "1.3.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.2.0.tgz",
-      "integrity": "sha512-wDUbYshckm+8ficjxlTMTljkV099xjLclYp0LokC4AMbZDhpR6vD6FAUQn7Fcc2QVK8v0qs21bDlfr6i+kcnHw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.3.0.tgz",
+      "integrity": "sha512-bL+KLGhwdh/AI4kTBW+U2kzA11jrAivJkoTRDmJw/YZ0/Ws2hiUCDPfWBmLn6cNQ1UjWB0if1pFqQkfycgJkVg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -1569,39 +1786,39 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.2.0.tgz",
-      "integrity": "sha512-c9qndqFuv8T3QQEOHDjgUvfreUKKdqwA8ntHZi3GJsdJIzyovWcMIid2WL6rbpswg2ob9rtgWAtpQOTqnO4ETw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.3.0.tgz",
+      "integrity": "sha512-qa1qZLwU9teems93krST74eH9eDu5dSoiOU8C4ndBl1KIuPs1vgmWMJDPApNdW+QMIniLiiX6hAWyV2YFaNVWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.2.0",
-        "@wormhole-foundation/sdk-connect": "1.2.0"
+        "@wormhole-foundation/sdk-algorand": "1.3.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-fThya7NTmpnLwvuhks4OlGTcc8sYFnbSHpfvyRZHERAaudMp6O1ziBhKkHBB1xeGQy1phVqZFYQozinq/RkjsA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-7OUmRZD7E7GGZBfTkCXufBQKaxHmoRX0w5MTx10LDRRAg/1Q6oxB+bnsLE3YDDo+qr3HZZmadiNW0A8UGau4kw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.2.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.2.0",
-        "@wormhole-foundation/sdk-connect": "1.2.0"
+        "@wormhole-foundation/sdk-algorand": "1.3.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.3.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.2.0.tgz",
-      "integrity": "sha512-yNh4wZvcnhHI+OZcwc/i9o4Q8dc/ipE5+JSpBcVSF2y+45+Tddu/OiIII0KAeyOslLARofrNZ5pS3seWa0J/WA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.3.0.tgz",
+      "integrity": "sha512-r32t/ceQzu8Fo8JCbidPJyM/Hd/RZG4OFB1swtmRe5Gr8vGoh3PrbDVaBukrnT7r/f6cudau37NI2GYlsXtD5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -1609,71 +1826,35 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.2.0.tgz",
-      "integrity": "sha512-a+9HjguUsRMi1oQs4NOpqgjWXPUVqIVJ5xU6WqAWTGNDwmGj2eVhi4UzzvcQ3NEh/b5g0xwxVDanOmlX/bHycA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.3.0.tgz",
+      "integrity": "sha512-fZvv3V8KUtljqNJNXxdqFFadfQoWq93VQSQ6pICAdCMeM62k31S+9m/mj7WJ+ctfp66fMZGbUejWVBVq7RKJ8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.2.0",
-        "@wormhole-foundation/sdk-connect": "1.2.0"
+        "@wormhole-foundation/sdk-aptos": "1.3.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-7xe+cOGu10fpSZcVgbR8jG5vdczK6TcWS3H1I+Em8iSMHy6XTzbQT8/Px9ePAsdaPsnBI0LHQKWHzAWduZ8pQA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-OsFNmjGH/37qOOwGt8m2NN7lZAk21QLLrjmI79BQ2Dq6TeQaQHtBwoK39aC/7P7RIGFU7cylA3I6iwWcDAH48Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.2.0",
-        "@wormhole-foundation/sdk-connect": "1.2.0"
+        "@wormhole-foundation/sdk-aptos": "1.3.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@noble/hashes": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-aptos/node_modules/aptos": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
-      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
-      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aptos-labs/aptos-client": "^0.1.0",
-        "@noble/hashes": "1.3.3",
-        "@scure/bip39": "1.2.1",
-        "eventemitter3": "^5.0.1",
-        "form-data": "4.0.0",
-        "tweetnacl": "1.0.3"
-      },
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-aptos/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.2.0.tgz",
-      "integrity": "sha512-sr9iece0N4OWHHlDGMLY723C8pgooJK93hQWj7FAcHapgwMpcdA9T7zaCqPLiKa2UqYYxGK+1AE/jVJz9vy4Zg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0.tgz",
+      "integrity": "sha512-/QpnDN6WBOOZC0mkeEmUWbUv/gLRY5aEl1U1mYXIInglSvIlARzFJtcFhxiuKMOZfufXM81j4G1XsZAWzff6lQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -1681,41 +1862,30 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.2.0.tgz",
-      "integrity": "sha512-PUAIjdQX9kStG6if7+2848xEKFPWGkjSqO1MH+219n02SQVObtkRb4+ricX5nERiWtux1tPbY7JDArOf1T3Okw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.3.0.tgz",
+      "integrity": "sha512-+zgylQsdv+o9YjrxjOlGnJDMAZUh+h/4MzTBlAAFbuP8/1WvIi/EXRP+yUpWWX2FB5OkH+SXzrcrbiWLg+HmIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.2.0",
-        "@wormhole-foundation/sdk-definitions": "1.2.0",
+        "@wormhole-foundation/sdk-base": "1.3.0",
+        "@wormhole-foundation/sdk-definitions": "1.3.0",
         "axios": "^1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-connect/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.2.0.tgz",
-      "integrity": "sha512-vBk9M/o056Hav2wh16T+ExrPD+TFTerbvltIJQk68V3XAXziBVrSgsq01uSA4shyh65Vy1K6BltKx+AO1GQ9MQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.3.0.tgz",
+      "integrity": "sha512-RkokeW17BF1WhzN1+Iwh/g+PX3ThXYP2DhKh1BjlV5GD0sL6ts2EDos5IGa5mEqaCB0C3DYXi1fFtXy9oMXP3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -1723,1634 +1893,71 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.2.0.tgz",
-      "integrity": "sha512-2tgv+mTnt8Gk+gZxYoaBnSGrKrH46dJn7n5AGOBMVV3PTgliETfSPHirFT7UeV1rYXE8QwCC7OFb/arAniijxg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.3.0.tgz",
+      "integrity": "sha512-gBEOU9OKszhUvuR2ev0kWBb0Cwk5B7GVCInRL3SebGY33y6IuNM1/ZEenkmfB9eYcE6yX8btGI2eukHCNBfRrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/networks": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "shx": "^0.3.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/utils": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
-      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "axios": "^1.6.4",
-        "bignumber.js": "^9.0.1",
-        "http-status-codes": "^2.2.0",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.1.2",
-        "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.6.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/cosmjs-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.2.0.tgz",
-      "integrity": "sha512-q3MFteWw3Xo0fhtJEF2Dnagc4Os35Y3zBxH8pQCctQWYN0gQhfXOy/JAHQW4gIsvSZDj8JRKRJK/ACL2x8zaww==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.3.0.tgz",
+      "integrity": "sha512-gkX5Dh6k08wybVYWqca0d79lkdXhgkIJjmRlKL7rYf22I3d3MT5F5nFbevx+w5GRig+DgsUCe0iJX6ks0xNxmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.3.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/networks": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "shx": "^0.3.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/utils": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
-      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "axios": "^1.6.4",
-        "bignumber.js": "^9.0.1",
-        "http-status-codes": "^2.2.0",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.1.2",
-        "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.6.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/cosmjs-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-6lpCQcXa+pywIK+sQHm7eYFwciTbjyMgtDZQ8xI27VZTfmJfMdcwiRiiE9+CsyfLKD+ykiaOp+fJPFRqfQ3dUg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-PKx5CeAhl9hJIwBVgFuC6LG8TUtXxt/E2DG1DHgxpQwpAEObm2apv6kk7GPVBTOYfmqAHnoL/2ldL0TjTdeV/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/networks": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "shx": "^0.3.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/utils": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
-      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "axios": "^1.6.4",
-        "bignumber.js": "^9.0.1",
-        "http-status-codes": "^2.2.0",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.1.2",
-        "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.6.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/cosmjs-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/networks": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "shx": "^0.3.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/utils": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
-      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "axios": "^1.6.4",
-        "bignumber.js": "^9.0.1",
-        "http-status-codes": "^2.2.0",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.1.2",
-        "store2": "^2.12.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.6.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/cosmjs-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.2.0.tgz",
-      "integrity": "sha512-RMk2iV5ImlNvAvsXrOqQZSZ/yZTAyIULwbIJ7HS0YhVcWPuv5Mi9HS3xsij5mFe//194vcqGk+kK2M0RmZ5Mjw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.3.0.tgz",
+      "integrity": "sha512-b5MSL10prMr9oH5gdgDlE8ZpNu1lhTd428FHOMCKlpMbdp3sTCu86TZkpc0lxlV+0s99LdAzMIZf7qW1AmcbBA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.6.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@wormhole-foundation/sdk-base": "1.3.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.2.0.tgz",
-      "integrity": "sha512-eNB2iqQJijGiBZFdOFh93mfWIQ3myHoyLxPTUJdf/vTq9Oh0zo/oJT+e3fzflU0IToJTewIUihf4/OsGz/BQ+g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.3.0.tgz",
+      "integrity": "sha512-aNwGJz8GDgS3Y6ELcrSnn6Z6khIMm1mFoZFgYVsnveCsrIIZPPvSZa5AKZW5UtUL5EhLTzqi3vzAMz3XtMUzBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3358,545 +1965,75 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.2.0.tgz",
-      "integrity": "sha512-jDd2j68IupDOkNCB2cJYx6GdaHgVfZm/8BGN+ywN55FMzzia/JfxX9PTeNFlXp6KLlwwocowGOZV7Lkba/kAOw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.3.0.tgz",
+      "integrity": "sha512-Sg9UdU9lzjzoudYcmyryRnItQ6LNC+Wk+FBAaF4Pyo3k3pKiQmpAn6/jzzH4zveNQzPuO0/c7dPswKk1730hzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-evm": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-evm": "1.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.2.0.tgz",
-      "integrity": "sha512-K9gr4Z44P4CGKRALw4R1LlaA86pQgLt4fU+C6YzETTbsbeXXxRxUmKmL47/AnXn95X9Zd0nGpIvKjNDQoXHi2w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.3.0.tgz",
+      "integrity": "sha512-V0/C/2SH8aIZ81Hn7ntP+CzYv+cmwhMYM8qEV+05hMrt1A5waKxgqSNavzQwDyG9O6XvV0DEJ3ZNFTk+OjfUUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-evm": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-evm": "1.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.2.0.tgz",
-      "integrity": "sha512-yMoPZ6FtujrYMGGZZ7NT2L43QC/S0xcnh6zBZz+9ES9uY6iE664m+BRB6FM+DLdNLH1i3Yd4kZW5cjBAJItJ6g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.3.0.tgz",
+      "integrity": "sha512-6dQHWDy/dbGssiwiPEuRAjm2fqRL9BPGLrpKvPuSeYgRdZ3oEPp/5aXNpONdLodEvo2Q8vKsx6ChXsjnTuOG7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-evm": "1.2.0",
-        "@wormhole-foundation/sdk-evm-core": "1.2.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-evm": "1.3.0",
+        "@wormhole-foundation/sdk-evm-core": "1.3.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-Qt3SNHrTdc+TL0K6IMg8u1R50LBZji5m23283mfmm9YYST1w+4nU/kIT4ylEnlMTqZtQHXIXKoi41arbSkvsYg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-s7mq84tNdribFSPUjAdTNLQahqqeTHO95K10Z8xvH785YWPAlNK5hdyItvEcZonHJl2wcaQMtvYXDErI6SDLgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-evm": "1.2.0",
-        "@wormhole-foundation/sdk-evm-core": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-evm": "1.3.0",
+        "@wormhole-foundation/sdk-evm-core": "1.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-evm/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.2.0.tgz",
-      "integrity": "sha512-eAObo/7S7Xu0VVK/ASrLbApg0AqIflRdu8lEIs7AkDIWQaufcyhNMgbL01zlyiOSovUIAUKyKci605Y/OCOOJQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.3.0.tgz",
+      "integrity": "sha512-oh7uCk5l3YWZiLvfqP+9lg5pOj6b/wrHBIPLbWQ5gfLS0ORiDT9wD0rH8DdMrSvny5XYZY+podtT2dBigbc9zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -3904,270 +2041,108 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.2.0.tgz",
-      "integrity": "sha512-growADK9XmTtwAJCu7u7rMcxi3Sw1V+5MtuBGPsnxdIi4PsArrJ/2zfKg87n1cISMtfLynmf5scKEqX93Nc2gw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.3.0.tgz",
+      "integrity": "sha512-vrFDNzy312vd3j5+HGPrcfxi5X9JQdMN0fdeUSKvhCZlRPDu/BFJXIWwq8UEvNIFPfgtx4hv1ih/Wz8jtSofiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-solana": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-solana": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.2.0.tgz",
-      "integrity": "sha512-v6r6i6sT5+GCdupdCZTmTmCo3jCgW9iJHg7ch3Sgs7/my1lzdKkBoou1Sy6NSPqllHe5x7Zjd7HB5zG5JCtBnQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.3.0.tgz",
+      "integrity": "sha512-elLxIDrdyFnDmfPuIpzkjrWWNiJy8dYq1GyVzERwBK/wKYAJ9AHFWP3CMYyUUXU/j3Oe0iMIhweK3ebHnlE77g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-solana": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-solana": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-solana-core/node_modules/@coral-xyz/borsh": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
-      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.1.2",
-        "buffer-layout": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.68.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-meiQXMviMSFlWUSJtw2ceM2Zm7DBVWn0HrqEi1qR6RvjSSEyPhyOx/FWSxKPJ+7MIJDP+aZcgy4hZgzLTuNqBQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-IhlprN9HU0kkXu8LRgIS0gKRvV3yEc0LYtVbdhJ/h8pRubWX2z2H9S5FPxsUGL4yWXIXIjCfnq4i67p8TCORyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-solana": "1.2.0",
-        "@wormhole-foundation/sdk-solana-core": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-solana": "1.3.0",
+        "@wormhole-foundation/sdk-solana-core": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-solana/node_modules/@coral-xyz/borsh": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
-      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.1.2",
-        "buffer-layout": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.68.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.2.0.tgz",
-      "integrity": "sha512-MeY8nLhXTAUtDAylDJgxc1ha4aQRkkEVlwEWq1DKTra02+hMTC/birywcLFzikr2Ay7ke+n6+67uYf0OTi1xcw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.3.0.tgz",
+      "integrity": "sha512-8TZG1JeK4YnMlWngwoaeWwpPNBh5YCHpltuoW5HkeX3H5GxZoNyjESOxwx00Yza7YKORzZJj0bwBraPjh3Hxtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui-cctp": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.3.0.tgz",
+      "integrity": "sha512-Dzgnlt20oKw+dgZSsI3uJohCGjLpU7rNpvp+ZKD/yz41pWGCvFyWUb83wZARPm1MhBQ5ZKUXF2MXJgwtPOeEmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-sui": "1.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.2.0.tgz",
-      "integrity": "sha512-afH4QrHaw4Qr4tdwOXTKXkSPubRC8wTFYmoskUhR+9bYaWiheRjLuBMkLYYZ4lHXeQazwDnaaHc7VuvmvCtc8w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.3.0.tgz",
+      "integrity": "sha512-m2NBG2JhxD88na2kuEY95ZtrJ/PQd0A0bP6mFJXGByh2io4kMM6Vi1sZvQNgXtHRu/NaSPvpwrB5TcqgNGcOwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-sui": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-sui": "1.3.0"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/bcs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/sui.js": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "0.11.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "@scure/bip32": "^1.3.1",
-        "@scure/bip39": "^1.2.1",
-        "@suchipi/femver": "^1.0.0",
-        "bech32": "^2.0.0",
-        "gql.tada": "^1.2.0",
-        "graphql": "^16.8.1",
-        "superstruct": "^1.0.3",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.2.0.tgz",
-      "integrity": "sha512-TY0fw4RP5FFx/kqPWFmwfoiiX2dqMIg9L6YtQ6GiD8/KFCu5sHuRqaHk2UYRUpHnygjpnJwn/TBIJZBps/fhWA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.3.0.tgz",
+      "integrity": "sha512-lbTZYo3WdUSUdfQ7pneZ8RonciPBtM2quiSgk0h6urw9wctkF7Lvbrq+I4yRouO8d1wP9/MrwvtPvqgP50YTXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.2.0",
-        "@wormhole-foundation/sdk-sui": "1.2.0",
-        "@wormhole-foundation/sdk-sui-core": "1.2.0"
+        "@wormhole-foundation/sdk-connect": "1.3.0",
+        "@wormhole-foundation/sdk-sui": "1.3.0",
+        "@wormhole-foundation/sdk-sui-core": "1.3.0"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/bcs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/sui.js": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "0.11.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "@scure/bip32": "^1.3.1",
-        "@scure/bip39": "^1.2.1",
-        "@suchipi/femver": "^1.0.0",
-        "bech32": "^2.0.0",
-        "gql.tada": "^1.2.0",
-        "graphql": "^16.8.1",
-        "superstruct": "^1.0.3",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/bcs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bs58": "^5.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/sui.js": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "0.11.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "@scure/bip32": "^1.3.1",
-        "@scure/bip39": "^1.2.1",
-        "@suchipi/femver": "^1.0.0",
-        "bech32": "^2.0.0",
-        "gql.tada": "^1.2.0",
-        "graphql": "^16.8.1",
-        "superstruct": "^1.0.3",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-sui/node_modules/base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "license": "MIT"
-    },
-    "node_modules/@wormhole-foundation/sdk-sui/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
       }
     },
     "node_modules/@wry/caches": {
@@ -4195,9 +2170,10 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
-      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4217,6 +2193,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -4231,6 +2213,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -4270,6 +2253,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
       "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
@@ -4278,6 +2262,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
       "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
+      "license": "MIT",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
@@ -4292,6 +2277,64 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/aptos": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
+      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
+      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aptos-labs/aptos-client": "^0.1.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip39": "1.2.1",
+        "eventemitter3": "^5.0.1",
+        "form-data": "4.0.0",
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/aptos/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/aptos/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/aptos/node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/aptos/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4322,17 +2365,31 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4354,7 +2411,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
@@ -4367,15 +2425,17 @@
       }
     },
     "node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
       "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.3.0"
       },
@@ -4384,9 +2444,10 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -4401,6 +2462,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4409,6 +2471,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
       "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
@@ -4416,12 +2479,14 @@
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -4434,6 +2499,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
       "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -4444,6 +2510,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4452,17 +2519,20 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
     },
     "node_modules/browser-headers": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==",
+      "license": "Apache-2.0"
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -4476,6 +2546,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -4484,6 +2555,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -4508,6 +2580,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4517,6 +2590,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
       "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.5"
       }
@@ -4524,13 +2598,15 @@
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
     },
     "node_modules/bufferutil": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -4570,6 +2646,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cheerio": {
       "version": "1.0.0",
@@ -4616,12 +2704,16 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/clone-response": {
@@ -4686,6 +2778,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4696,17 +2789,26 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/cosmjs-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -4719,6 +2821,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -4732,6 +2835,7 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
       "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -4740,6 +2844,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
       "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4841,11 +2946,30 @@
         "node": ">=10"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -4875,6 +2999,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4886,6 +3011,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4962,15 +3088,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -4982,9 +3110,10 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",
@@ -5022,15 +3151,35 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
@@ -5093,6 +3242,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -5115,6 +3265,8 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "deprecated": "This library has been deprecated and usage is discouraged.",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -5124,19 +3276,22 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -5151,6 +3306,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -5162,10 +3318,99 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ethers": {
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
+      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
       "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -5178,12 +3423,14 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -5205,23 +3452,26 @@
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5235,6 +3485,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5247,23 +3498,14 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
-      },
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5302,6 +3544,8 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5318,11 +3562,13 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5332,9 +3578,22 @@
       }
     },
     "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/got": {
       "version": "11.8.6",
@@ -5381,9 +3640,10 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -5392,6 +3652,7 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -5402,45 +3663,13 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5450,6 +3679,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -5463,20 +3693,35 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hi-base32": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
-      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==",
+      "license": "MIT"
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -5487,6 +3732,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -5542,9 +3788,10 @@
       }
     },
     "node_modules/http-status-codes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -5577,6 +3824,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -5611,12 +3859,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5625,12 +3876,14 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -5676,11 +3929,15 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5690,6 +3947,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -5715,14 +3973,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/jayson": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.2.tgz",
-      "integrity": "sha512-5nzMWDHy6f+koZOuYsArh2AXs73NfWYVlFyJJuCedr93GpY+Ku8qq10ropSXVfHK+H0T6paA88ww+/dV+1fBNA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
       "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
@@ -5748,48 +4007,32 @@
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "node_modules/jayson/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
     },
     "node_modules/js-sha512": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5822,6 +4065,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.3.tgz",
       "integrity": "sha512-lryZl0flhodv4SZHOqyb1bx5sKcJxj0VBo0Kzb4QMAg3L021IC9uGpl0RCZa+9KJwlRGSK2C80ITcwbe19OKLQ==",
+      "license": "MIT",
       "bin": {
         "jscrypto": "bin/cli.js"
       }
@@ -5830,6 +4074,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -5848,7 +4093,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -5856,12 +4102,14 @@
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "engines": [
         "node >= 0.2.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -5874,10 +4122,11 @@
       }
     },
     "node_modules/keccak": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
-      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -5891,6 +4140,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.6.tgz",
       "integrity": "sha512-8GLiM01PkdJVGUhR1e6M/AvWnSqYS0HaERI+K/QtStGDGlSTx2B1zTqZk4Zlqu5TxHJNTxWAdP9Y+WI50OApUw==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -5947,12 +4197,14 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5964,6 +4216,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -5991,6 +4244,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -6143,6 +4397,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -6159,6 +4414,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6167,6 +4423,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6186,17 +4443,20 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6208,6 +4468,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6249,6 +4510,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -6257,7 +4519,8 @@
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "license": "MIT"
     },
     "node_modules/node-email-verifier": {
       "version": "2.0.0",
@@ -6277,6 +4540,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6293,9 +4557,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -6331,6 +4596,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6339,6 +4605,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -6347,6 +4614,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -6415,7 +4683,8 @@
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -6461,6 +4730,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6468,12 +4738,14 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -6498,6 +4770,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6505,10 +4778,11 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6520,17 +4794,14 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^4.0.0"
       },
-      "engines": {
-        "node": ">=12.0.0"
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
-    },
-    "node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
@@ -6591,6 +4862,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6598,12 +4870,14 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6616,7 +4890,8 @@
     "node_modules/readonly-date": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
-      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
+      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -6628,6 +4903,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/rehackt": {
       "version": "0.1.0",
@@ -6656,16 +4937,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6681,6 +4966,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
       "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -6701,6 +4987,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -6710,6 +4997,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
       "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -6737,9 +5025,10 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6760,6 +5049,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6781,7 +5071,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6800,21 +5091,29 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
     },
     "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
         "node-gyp-build": "^4.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -6831,12 +5130,14 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6888,6 +5189,7 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -6904,6 +5206,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
       "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -6939,19 +5242,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.6.tgz",
-      "integrity": "sha512-7ipeNts8YTLbx/6zIaT1mQGrHG2vK+0TjywPD79QzIDJDcvNXBLX7DXQOt6by4DFdncu8lDPc+QHKHemtDEoQg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.5.0.tgz",
+      "integrity": "sha512-r3kRtnoPu3FxGJ3fny6PKNnU3pteb29o6qAa0ugzhSseKNWRkw1dw8nIjXMyyKaU9vQxxVIE62Mb3bKbdrgpiw==",
+      "license": "MIT",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
-        "type-fest": "^2.5.2"
+        "type-fest": "^3.12.0"
       },
       "engines": {
         "node": ">=12"
@@ -7004,14 +5309,16 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/store2": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
-      "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w=="
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.3.tgz",
+      "integrity": "sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7020,6 +5327,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -7029,17 +5337,16 @@
       }
     },
     "node_modules/superstruct": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
-      "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7067,6 +5374,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -7079,22 +5387,26 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
       "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -7111,19 +5423,22 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "license": "Unlicense"
     },
     "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7177,6 +5492,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -7188,12 +5504,14 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7211,12 +5529,14 @@
     "node_modules/vlq": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
-      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
+      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
@@ -7245,6 +5565,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7253,12 +5574,14 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -7295,6 +5618,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
       "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "license": "MIT",
       "dependencies": {
         "globalthis": "^1.0.1",
         "symbol-observable": "^2.0.3"
@@ -7304,6 +5628,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
       "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -7311,12 +5636,14 @@
     "node_modules/zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
       "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
       }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^22.10.1",
+    "@types/node": "^22.10.2",
     "markdown-link-check": "^3.13.6",
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "1.2.0",
+    "@wormhole-foundation/sdk": "1.3.0",
     "sharp": "^0.33.5",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/chains/Noble.json
+++ b/scripts/src/chains/Noble.json
@@ -1,0 +1,23 @@
+{
+  "title": "Noble",
+  "homepage": "https://www.noble.xyz/",
+  "testnet": {
+    "name": "Testnet",
+    "id": "grand-1"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "noble-1"
+  },
+  "devDocs": "https://docs.noble.xyz/",
+  "faucet": {
+    "url": "https://faucet.circle.com/",
+    "token": "USDC",
+    "description": "Circle Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://docs.noble.xyz/network/resources",
+    }
+  ]
+}

--- a/scripts/src/chains/pythnet.json
+++ b/scripts/src/chains/pythnet.json
@@ -3,7 +3,9 @@
   "homepage": "https://www.pyth.network/",
   "devDocs": "https://docs.pyth.network/home",
   "faucet": {
-    "url": "https://console.optimism.io/faucet"
+    "url": "https://console.optimism.io/faucet",
+    "description": "Superchain Faucet",
+    "token": "ETH"
   },
   "explorer": [
     {

--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -25,11 +25,11 @@ export function generateAllChainIdsTable(dc: cfg.DocChain[]): string {
   for (const c of orderedDc) {
     // Assemble the Mainnet table data
     const mainnetAlias = cfg.networkString(c.mainnet.extraDetails?.mainnet);
+    const mainnetName = c.mainnet.extraDetails?.title ? c.mainnet.extraDetails.title : c.mainnet.name
+
     mainNetTableBody.push(
       `<tr>
-        <td>${
-          c.mainnet.extraDetails ? c.mainnet.extraDetails.title : c.mainnet.name
-        }</td>
+        <td>${mainnetName}</td>
         <td><code>${c.mainnet.id}</code></td>
         <td>${mainnetAlias}</td>
       </tr>`


### PR DESCRIPTION
This PR does a couple things:

- Bumps sdk version to 1.3.0
- Updates pyth configs
- Add new configs for Noble (introduced in 1.3.0)
- Fixes fallback logic for the name