### PR TITLE
update submodule to c2f7be6 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Wormhole Docs
 site_url: https://wormhole.com/docs/
 docs_dir: wormhole-docs
 copyright: 2024 © Wormhole Foundation. All Rights Reserved.
+edit_uri: https://github.com/wormhole-foundation/wormhole-docs/edit/main/
 extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/terminal.css
@@ -134,4 +135,4 @@ extra:
           data: 0
           note: >-
             Thanks for your feedback! Help us improve this page by submitting
-            <a href="https://github.com/wormhole-foundation/wormhole-docs/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">additional feedback</a>.
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdRjp_CJ2jEC0gPvK242zRzJoN_x9-Nlt_KXkCy7QPYiD4OlA/viewform?usp=pp_url&entry.2090824420=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">additional feedback</a>.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ mkdocs-material==9.5.24
 mkdocs-material-extensions==1.3.1
 mkdocs-redirects==1.2.0 
 nltk==3.8.1
-Pillow==9.4.0
+Pillow==11.1.0
 Pygments==2.18.0
 pymdown-extensions==10.8.1
 python-dateutil==2.8.2

--- a/scripts/src/chains/arbitrum.json
+++ b/scripts/src/chains/arbitrum.json
@@ -16,7 +16,7 @@
     }
   ],
   "finality": {
-    "details": "https://docs.arbitrum.io/how-arbitrum-works/tx-lifecycle",
+    "details": "https://docs.arbitrum.io/how-arbitrum-works/transaction-lifecycle",
     "instant": 200,
     "safe": 201,
     "otherwise": "finalized"


### PR DESCRIPTION
This updates the submodule to include the following wormhole-docs PRs:

- https://github.com/wormhole-foundation/wormhole-docs/pull/201
- https://github.com/wormhole-foundation/wormhole-docs/pull/203
- https://github.com/wormhole-foundation/wormhole-docs/pull/205
- https://github.com/wormhole-foundation/wormhole-docs/pull/208
- https://github.com/wormhole-foundation/wormhole-docs/pull/209
- https://github.com/wormhole-foundation/wormhole-docs/pull/210
- https://github.com/wormhole-foundation/wormhole-docs/pull/211

and the following mkdocs PRs:

- https://github.com/papermoonio/wormhole-mkdocs/pull/122
- https://github.com/papermoonio/wormhole-mkdocs/pull/126
- https://github.com/papermoonio/wormhole-mkdocs/pull/130