### PR TITLE
add redirects for multichain tokens and the NTT tutorials section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,8 @@ plugins:
         build/start-building/supported-networks/sui.md: build/start-building/supported-networks.md
         build/contract-integrations/gateway.md: build/start-building/supported-networks/cosmos.md
         learn/messaging/gateway.md: learn/messaging/index.md
+        tutorials/by-product/native-token-transfers/index.md: tutorials/by-product/index.md
+        tutorials/by-product/native-token-transfers/multichain-token.md: tutorials/by-product/multichain-assets/multichain-token.md
         tutorials/messaging/cctp.md: tutorials/by-product/wormhole-sdk/usdc-via-cctp.md
         tutorials/messaging/cross-chain-contracts.md: tutorials/by-product/contract-integrations/cross-chain-contracts.md
         tutorials/messaging/cross-chain-token-contracts.md: tutorials/by-product/contract-integrations/cross-chain-token-contracts.md
@@ -89,6 +91,7 @@ plugins:
         tutorials/messaging/token-bridge.md: tutorials/by-product/wormhole-sdk/tokens-via-token-bridge.md
         tutorials/multigov/index.md: tutorials/by-product/multigov/index.md
         tutorials/multigov/treasury-proposal.md: tutorials/by-product/multigov/treasury-proposal.md
+      
   - macros:
       include_yaml:
         - wormhole-docs/variables.yml


### PR DESCRIPTION
This goes with the changes made in https://github.com/wormhole-foundation/wormhole-docs/pull/220/files

Adds redirects for the multichain tokens page and also for the native token transfers index page for now. We'll be able to remove this once we create a NTT tutorial and add the section back