### PR TITLE
fix cookbook script

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -72,13 +72,15 @@
 
 {% block scripts %}
   {{ super() }}
-  <script>
-    document.body.addEventListener('click', (event) => {
-      if (event.target.tagName === 'ASK-COOKBOOK') {
-        event.target.addEventListener('keydown', (event) => {
-          event.stopPropagation()
-        })
-      }
+  <script defer>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.addEventListener('click', (event) => {
+        if (event.target.tagName === 'ASK-COOKBOOK') {
+          event.target.addEventListener('keydown', (event) => {
+            event.stopPropagation();
+          });
+        }
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
This fixes the fail-safe cookbook script by deferring the script until all the HTML is parsed and ensuring the DOM has been loaded before accessing `document.body`. Ultimately, this should fix the issue where you type in a keyboard shortcut and the page would reload instead of allowing you to type a question to cookbook