### PR TITLE
update width issue causing horizontal scrolling

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -929,6 +929,10 @@ pre .md-clipboard {
   font-size: var(--body-xs-text-size);
 }
 
+.feedback__section {
+  width: 100%;
+}
+
 .md-feedback {
   margin-top: 0;
   margin-bottom: 0.75em;
@@ -952,7 +956,6 @@ pre .md-clipboard {
 
 /* Divider Styling */
 .divider {
-  width: 15vw;
   height: 1px;
   background-color: var(--light-transparent-20);
   margin: 0.75em auto 0;


### PR DESCRIPTION
I had set a width to an element (`.divider`) that, depending on the screen size, was extending the width of the TOC and causing a horizontal scrollbar to appear. So this fixes it by imposing the width changes on the parent element to take up the full width instead of trying to override it with a specific width