### PR TITLE
update consistency levels from s to min

### DIFF
--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -136,8 +136,8 @@ export function generateAllConsistencyLevelsTable(dc: cfg.DocChain[]): string {
 
     if (finalizationBlocks !== undefined && blockTime !== undefined) {
       const finalizationTime = `~ ${Math.ceil(
-        ((finalizationBlocks + 1) * blockTime) / 1000
-      )}s`;
+        ((finalizationBlocks + 1) * blockTime) / 1000 / 60
+      )}min`;
       tableBody.push(`
 <tr>
   <td>${header}</td>

--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -135,10 +135,6 @@ export function generateAllConsistencyLevelsTable(dc: cfg.DocChain[]): string {
     const blockTime = finality.blockTime.get(toChain(c.mainnet.id));
 
     if (finalizationBlocks !== undefined && blockTime !== undefined) {
-      // const finalizationTime = `~ ${Math.ceil(
-      //   ((finalizationBlocks + 1) * blockTime) / 1000 / 60
-      // )}min`;
-
       const finalizationSeconds = ((finalizationBlocks + 1) * blockTime) / 1000;
   
       const finalizationTime = finalizationSeconds < 120

--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -135,9 +135,16 @@ export function generateAllConsistencyLevelsTable(dc: cfg.DocChain[]): string {
     const blockTime = finality.blockTime.get(toChain(c.mainnet.id));
 
     if (finalizationBlocks !== undefined && blockTime !== undefined) {
-      const finalizationTime = `~ ${Math.ceil(
-        ((finalizationBlocks + 1) * blockTime) / 1000 / 60
-      )}min`;
+      // const finalizationTime = `~ ${Math.ceil(
+      //   ((finalizationBlocks + 1) * blockTime) / 1000 / 60
+      // )}min`;
+
+      const finalizationSeconds = ((finalizationBlocks + 1) * blockTime) / 1000;
+  
+      const finalizationTime = finalizationSeconds < 120
+      ? `~ ${Math.ceil(finalizationSeconds)}s`
+      : `~ ${Math.ceil(finalizationSeconds / 60)}min`;
+
       tableBody.push(`
 <tr>
   <td>${header}</td>


### PR DESCRIPTION
changes the consistency level table to show the time in minutes instead of seconds 