### PR TITLE
Publish a81ea77 and fix dropdown

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -218,6 +218,10 @@
   font-size: var(--label-size);
 }
 
+.md-tabs {
+  z-index: unset;
+}
+
 /* To align with Wormhole website */
 .md-header {
   /* Make header a little thicker */
@@ -1376,6 +1380,7 @@ label[for='__drawer'] svg {
   padding: 0;
   margin: 1.5em -1em;
   transform: translateZ(0);
+  will-change: transform;
 }
 
 .md-tabs__item--custom:hover .md-tab__list,

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "1.13.1",
+        "@wormhole-foundation/sdk": "1.13.2",
         "sharp": "^0.33.5",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
-        "@types/node": "^22.13.9",
-        "markdown-link-check": "^3.13.6",
+        "@types/node": "^22.13.10",
+        "markdown-link-check": "^3.13.7",
         "typescript": "^5.8.2"
       }
     },
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@apollo/client": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.2.tgz",
-      "integrity": "sha512-czLeqQuRB3RqcpEWFTJ/wfT+povpLfGAsprP2i9rsKj5PkH94IrFaI7ETtTMwOrycWFw/MJX9HCFGBslB/MGNg==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.4.tgz",
+      "integrity": "sha512-Ot3RaN2M/rhIKDqXBdOVlN0dQbHydUrYJ9lTxkvd6x7W1pAjwduUccfoz2gsO4U9by7oWtRj/ySF0MFNUp+9Aw==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1289,58 +1289,35 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.4.0.tgz",
-      "integrity": "sha512-YwDYspceLt8b7v6ohPvy8flQEi+smtfSG5d2A98CbUA48XBmOqTSPNmpw9wsZVVnrH2avr+BS5uVhDZT+EquYA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.5.0.tgz",
+      "integrity": "sha512-v39dm5oNfKYMAf2CVI+L0OaJiG9RVXsjqPM4BwTKcHNCZOvr35IIewGtXtWXsI67SQU2TRq8lhQzeibdiC/CNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "bs58": "^6.0.0"
-      }
-    },
-    "node_modules/@mysten/bcs/node_modules/base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==",
-      "license": "MIT"
-    },
-    "node_modules/@mysten/bcs/node_modules/bs58": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^5.0.0"
+        "@scure/base": "^1.2.4"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.21.2.tgz",
-      "integrity": "sha512-8AesvczokAUv796XiOo8af2+1IYA9bRon11Ra+rwehvqhz+sMRT8A+Cw5sDnlSc9/aQwM51JQKUnvMczNbpfYA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.24.0.tgz",
+      "integrity": "sha512-lmJJLM7eMrxM6Qpr6cdLr07UBXlxCM7SJjfcDO7NGrqZTx7/3TD2QhhRpDx0fS2tODxrNwQxCoHPApLVPjokIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.4.0",
+        "@mysten/bcs": "1.5.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
+        "@scure/base": "^1.2.4",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
-        "@suchipi/femver": "^1.0.0",
-        "bech32": "^2.0.0",
         "gql.tada": "^1.8.2",
         "graphql": "^16.9.0",
-        "jose": "^5.6.3",
         "poseidon-lite": "^0.2.0",
         "valibot": "^0.36.0"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@mysten/sui/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
     },
     "node_modules/@noble/curves": {
       "version": "1.8.1",
@@ -1663,12 +1640,6 @@
         }
       }
     },
-    "node_modules/@suchipi/femver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
-      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
-      "license": "MIT"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1759,9 +1730,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1811,50 +1782,50 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.13.1.tgz",
-      "integrity": "sha512-sN+WmVu0Sf8JTECE8fE7XbxyHBnGE7lF0CzAiJUIZZyt9MnvjcFEb/RLAvcYiF0hAWfGzRNAiLwjGAdkCVrj1Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.13.2.tgz",
+      "integrity": "sha512-cZHMh1n2+/Y93TAEXd6u4rGzHNmHW4o3kA0r5BkcwozAKnSFO7f6G87CQ6Dx58U9SUJK/rM65bAntNWDu62sww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.13.1",
-        "@wormhole-foundation/sdk-algorand-core": "1.13.1",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.13.1",
-        "@wormhole-foundation/sdk-aptos": "1.13.1",
-        "@wormhole-foundation/sdk-aptos-cctp": "1.13.1",
-        "@wormhole-foundation/sdk-aptos-core": "1.13.1",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.13.1",
-        "@wormhole-foundation/sdk-base": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.13.1",
-        "@wormhole-foundation/sdk-definitions": "1.13.1",
-        "@wormhole-foundation/sdk-evm": "1.13.1",
-        "@wormhole-foundation/sdk-evm-cctp": "1.13.1",
-        "@wormhole-foundation/sdk-evm-core": "1.13.1",
-        "@wormhole-foundation/sdk-evm-portico": "1.13.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.13.1",
-        "@wormhole-foundation/sdk-solana": "1.13.1",
-        "@wormhole-foundation/sdk-solana-cctp": "1.13.1",
-        "@wormhole-foundation/sdk-solana-core": "1.13.1",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.13.1",
-        "@wormhole-foundation/sdk-sui": "1.13.1",
-        "@wormhole-foundation/sdk-sui-cctp": "1.13.1",
-        "@wormhole-foundation/sdk-sui-core": "1.13.1",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.13.1"
+        "@wormhole-foundation/sdk-algorand": "1.13.2",
+        "@wormhole-foundation/sdk-algorand-core": "1.13.2",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.13.2",
+        "@wormhole-foundation/sdk-aptos": "1.13.2",
+        "@wormhole-foundation/sdk-aptos-cctp": "1.13.2",
+        "@wormhole-foundation/sdk-aptos-core": "1.13.2",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.13.2",
+        "@wormhole-foundation/sdk-base": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.13.2",
+        "@wormhole-foundation/sdk-definitions": "1.13.2",
+        "@wormhole-foundation/sdk-evm": "1.13.2",
+        "@wormhole-foundation/sdk-evm-cctp": "1.13.2",
+        "@wormhole-foundation/sdk-evm-core": "1.13.2",
+        "@wormhole-foundation/sdk-evm-portico": "1.13.2",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.13.2",
+        "@wormhole-foundation/sdk-solana": "1.13.2",
+        "@wormhole-foundation/sdk-solana-cctp": "1.13.2",
+        "@wormhole-foundation/sdk-solana-core": "1.13.2",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.13.2",
+        "@wormhole-foundation/sdk-sui": "1.13.2",
+        "@wormhole-foundation/sdk-sui-cctp": "1.13.2",
+        "@wormhole-foundation/sdk-sui-core": "1.13.2",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.13.1.tgz",
-      "integrity": "sha512-AgPcaJFmvLVxnzNrzWi24TZEneUt0d26f8us4Q2QsG0XBVNgmlzQDZVcdfLiM/vrCGMWvCB00TQ3hca/sHQWtg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.13.2.tgz",
+      "integrity": "sha512-BRklytrMHhw5BUwraOVf0suxfqB9d//3eY2c5YUhkwVKT5uEaJNTCkbZO7sw8R5Pexlf9YCge/mVMp1X1yyMrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -1862,89 +1833,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.13.1.tgz",
-      "integrity": "sha512-RqD0qh7PNfaMprkcdxR7Qt5Fb00PoSRpvH9A9zBYv0+DgAchAvDiT0eYOHkOr5BBg0qS4tb7WXz1u9B6K0IcvQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.13.2.tgz",
+      "integrity": "sha512-vdFBKvzLGyg76uoGRdfXvWr91uj7e5ji30Gjp4hZe0xjbJ0Yi6X+3l26T7wEDtA0k6nVGV6dWLMy4kHaKbE+oQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-algorand": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-dWVhsZPfIW/3pfK8FSez/POI8kp9OCOUNjIhkHI5WsoBQrQlrbfF9aUc3QCOxARQQGXh/nruoui2zNmWlYqegQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-nQyQvxp02QJszkz9ZFrlayB5mLhpxt+vsnQlUwSMpfsqm/CNRSvg8KFVKG9JiM7OYboWD1j8nKdzfBGA8sQ9VQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.13.1",
-        "@wormhole-foundation/sdk-algorand-core": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-algorand": "1.13.2",
+        "@wormhole-foundation/sdk-algorand-core": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.13.1.tgz",
-      "integrity": "sha512-LaCYJVu6lI3Ur795wxyXhfPf+jGnmbQX+RtHnPQICh1ikRABnu+bvUys6evUW1pDb4zUuOXLxuDijZWtjvYqVQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.13.2.tgz",
+      "integrity": "sha512-lljZcoIVJ3jCLl+u1m+PiD/AChHj54tJDWPbtPnoRBDdChC43HCA4UrGQOQzh55bkbEaT7g0yfvylLU2YtFgNA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-1.13.1.tgz",
-      "integrity": "sha512-byycUK4+ghH5766WIfpON75OBXSjJIGwGyOrs9stYXnJYJCERCd8TuXRH7ZvRIR1dEUCAlmTXmG2vDm1tpBj8Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-1.13.2.tgz",
+      "integrity": "sha512-r3YS5l0Qd736XYOeEbLQ6wHf85qe0GVYfbdsP6GHwrBV11hA5LUUfVPVpyofcGR0CqpwaZQTdOw+UuaxDwlJDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
-        "@wormhole-foundation/sdk-aptos": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-aptos": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.13.1.tgz",
-      "integrity": "sha512-vTs7+074DhWHVm38cuEdIj9LmM6HIIEbPXxIo8Z42F3GNj/JpNmv9nqdRo7dob2sUg/xFaKivgNvylIHxIA4mw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.13.2.tgz",
+      "integrity": "sha512-31xMChfi+E1wF+W32cLAFfNbViHI3q7Lf+yXrqkcHU0qgGPZ0mZ4/CqN6wueZ61LlhwNJjCbCntJIlKuj8VLsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-aptos": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-XBnxeZdMbA1X1dwxSEXdgydv8dlE4d7Nm3AqQdpMVWFt2AcLC+UbUIv60QmOntSqR3A/nY5ZaCnoEw9KIwy2MA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-6jlGl63iOcOFGg7GaCjUeJkgZ+Wj5JQ26n5doX8RMeR+kqhVXEKUzNQLG3uzLUCbPYGYeCepBP6oBtvaVd+rOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.13.1",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-aptos": "1.13.2",
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.13.1.tgz",
-      "integrity": "sha512-tPsFB1NKFX5bUi0gw+2lZ3ebOfuxdZxJFpwJdq/37Hqp53gCepOAEiItNZAZIKIPYbF53f662wG15rUZdKVYWA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.13.2.tgz",
+      "integrity": "sha512-3vffr+gTR1afQjsxGZXzV8WHO6/Wd4a7ppD5d0rGFA3JNMw5iWe3/7y7YOFAA+QXowp+55cgk4WNnxzVIHaVqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -1952,13 +1923,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.13.1.tgz",
-      "integrity": "sha512-rU4p5cLUpQKCm8m8uIjPsbEmSd1y3Iju3GGrTZK3iHLoC3V9pXSzh7gbDJZ76h7vwPG4ZI57b9ZObOAk7EiwsQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.13.2.tgz",
+      "integrity": "sha512-0YKdhI/L3IKRxEGfguYAnzH6kbdlWQPtEO+VaomVuKN7XM+aYBrAUCMauA6/JAYY+MMXwQsnHUfrfdLXhcsT6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.13.1",
-        "@wormhole-foundation/sdk-definitions": "1.13.1",
+        "@wormhole-foundation/sdk-base": "1.13.2",
+        "@wormhole-foundation/sdk-definitions": "1.13.2",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -1966,16 +1937,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.13.1.tgz",
-      "integrity": "sha512-aWXy0aQdTC3VHP7ohvTD2lIzLgRmRpY8n0wWipFzZjwrRcICfCbr466sdW6jBQ20LIbifS3OtxyhES4I5/i7EA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.13.2.tgz",
+      "integrity": "sha512-5pvxxcWFE3nGoVAT01LbHSrqJEegXuexUA1eVxSaeH70nM9EuxdHXRxkfEHezCs2osoPe9HFYroOYSKkxRvswQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -1983,33 +1954,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.13.1.tgz",
-      "integrity": "sha512-xjQettKS5QKr/dPKdfPmS7DGDuMVVH1NJWCNS/u/UQNNpLHe50f1Dj8MsMhTDiOuQtQBpNEh9IoTeeoiTZaSEg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.13.2.tgz",
+      "integrity": "sha512-NXOr96paLLfc94h1umSVpX20Qhttx/CNj7bDWAAs+G2AzqyFGLRZWuhDSuQPu3W/5x4X/p4DNHNw18fQ/rppnA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.13.1.tgz",
-      "integrity": "sha512-UEXUFYyBpXy0UW4zbIswbdtQ1lgGEA24czBlysxiZqwDSjuxz1yZGswm6ajP/hY1makXXKVp6fjumvVdDGsnWg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.13.2.tgz",
+      "integrity": "sha512-P8k1i+k0ZI8CcEKW4DwJv4e2Fb2aDy6YldgPE+ErOmKX7xt6Y3VkVaZt+pGu/hGhBQSIGs6Jx0p2Wy78DRhTqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.13.2",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2017,37 +1988,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-vqFuScGtRnskoRV6IbLZsktEiQ/S6Y3Rp/a1WwVM6K8pBRnxEShI+SJKr8AXZ653pNM8BsjIs77e/WI7Cpy2rw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-c66AcWRniRVmWvcjtcQRynCM89fxxON1dT62fL5jUDoKxs2xd0aGhVSIL07D2qstLQolx6UCNOxf/H0mBloWOA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-cosmwasm": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.13.1.tgz",
-      "integrity": "sha512-7UoQ0jhlDmWQND85kgEl5PoW8MefbgWOhI1AaSUQDJxqclfvClPq8eSM7txOdKNb3ogNqHZBuDNCm6y9LFTXZw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.13.2.tgz",
+      "integrity": "sha512-oE2ppRsjrdCpvFkMiqNnQmOXMa19H0BF4RueeYaMrtE057J6YukmZbUeLcQrF52ZsJ7fAtgorOfPJYNOCxdadQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.13.1"
+        "@wormhole-foundation/sdk-base": "1.13.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.13.1.tgz",
-      "integrity": "sha512-jdUt3JO2e7ruqbA6SrnVi1/UrnYLyY0qf1uPQLVUWMnivP2QioxEMWc5NK6LYZuUb8cLP9njgsq4i5K22Eum5g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.13.2.tgz",
+      "integrity": "sha512-WCyk44cbBtG+9VSOSj6UToGhaH4Os1efsBbGStfQzUdwGQ0z6GSo8G4aHet5CFVSZHj7PigvU3iwPirKkidfBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2055,13 +2026,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.13.1.tgz",
-      "integrity": "sha512-fnKQQw2PqDLJ0M7GdL48HzGvaEY/MlzEp/UBMA9q5LXEsNBwc4p/ywK7/1PtIjjjJIfQRt7wSRtep1FaChFCyA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.13.2.tgz",
+      "integrity": "sha512-FQlMR9i1L1GfLp4kqdSVBwbzNFl8XUJWbKOsO0ezEAzcW0IguH//3DLqc5qPfq1A+y4QVuCHNgNty1vj3Xtjsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-evm": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-evm": "1.13.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2069,13 +2040,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.13.1.tgz",
-      "integrity": "sha512-rXBuNws3nHMbTeAvz7kEschKcT2Jq860SIZQkjWN6M+GCjH6qRdfsVVLcbTxjPGbC0yOqE3X3BCeldhDoHVrKQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.13.2.tgz",
+      "integrity": "sha512-V8kg+8DJa8lIIAtOkDbjx1QkhbUDtxM1L7NoRnfZ7IHqcwc54UuOlULpe+GxywYiXWfq99NfOHfbzq65jRwyjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-evm": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-evm": "1.13.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2083,15 +2054,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.13.1.tgz",
-      "integrity": "sha512-hqy9pp14yX6fbZ5MFtE1NTRz0By1siEFrW8dvy8CvBNEzU+/OdthntFnojkgmDO1jxObelCKkEKAfIz1F5Tmww==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.13.2.tgz",
+      "integrity": "sha512-qN4z+YWDQyQkCe94b0sgjb84rKoUGZqMd0rxn/LR+a6Qbc/PyTTGeToRoXs19GWDYlNR8EQ5gXkDV47skFA/yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-evm": "1.13.1",
-        "@wormhole-foundation/sdk-evm-core": "1.13.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-evm": "1.13.2",
+        "@wormhole-foundation/sdk-evm-core": "1.13.2",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.13.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2099,14 +2070,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-clbP0Xy2GCk8HbizlSHSsx7eiuNHjsXAWiZsGRAnhqvysVE5sSgUbNimt8pdqzDxAocv/VLchGJFHnS0Ez+l2A==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-yFMczTmcRXRbuWuUjqaUesFrmpkf81k5E1XLs/cdbuG4nIBEumVY9upi46zlGm5KUK5wre6iZdlVfvxWOivg3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-evm": "1.13.1",
-        "@wormhole-foundation/sdk-evm-core": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-evm": "1.13.2",
+        "@wormhole-foundation/sdk-evm-core": "1.13.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2114,16 +2085,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.13.1.tgz",
-      "integrity": "sha512-Jk0GvEvoohHZ1EOaIdVk4cbHkJ2GwKwy6X/fkk6bpa3Itn7+zDg5Pcqad0zUcNhQhk9iGaMrZNu1iPNG4hffAg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.13.2.tgz",
+      "integrity": "sha512-kwNBUqCnDXVYa5sPUZH7jKzUAxvCW61/ER8fdRlUM6r+NSeqS+xK+LE3gcStjlFMfnbk61n02oDuiI3HUiaafQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
+        "@wormhole-foundation/sdk-connect": "1.13.2",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2131,105 +2102,105 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.13.1.tgz",
-      "integrity": "sha512-oWDiOHeBWvJCKM/jKeFTrNQr/tIX4wvRs136zRBwe3G95oCbej7gIGV2/bq+s9bzlsQ+SLzclkkR640UPhvQ4A==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.13.2.tgz",
+      "integrity": "sha512-UDxSYp9En70PUrvlMjpk6XwXCB10MQeTIIWfFCtld70PoWn9opLfaLjce1rjFE5wf9aIbnfq7ED8yqZZ11lNOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-solana": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-solana": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.13.1.tgz",
-      "integrity": "sha512-6khWrkKbMqPtLOA86Aq5D73kU82cXaFKOCHUXEiGjytTksDFXxTSjlNLoN8jGfXSfDoIMtmdFY2bGbZoG9uqTA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.13.2.tgz",
+      "integrity": "sha512-RcdSmzB6NG7di8pW4uqKG4dCUIcmzFip+CjhO7y7dTrm1ViJU7EkuiYcRVN890WRflNIqdyO+DGfKVMbUYcobg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-solana": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-solana": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-f5r+jdrFjsMLtSQoQ1w/TEKyOlyYtE65y4wcSDOmQyaIHziPTaZn8zPu8zHLLyOEbqwAb8vkUfaAH3DLKDSZWg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-/fzH03F9CEG5LXLyw134yNgM3vbHh9KyiLNywM8qmddAX06lnAFoKFcJO8dyZWhDI1ilf8M2hyNLzvvMIdkJnA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-solana": "1.13.1",
-        "@wormhole-foundation/sdk-solana-core": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-solana": "1.13.2",
+        "@wormhole-foundation/sdk-solana-core": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.13.1.tgz",
-      "integrity": "sha512-V36Vdas+e74TsXxVXPrGd3zxBMYnHJCVsmE1Raea9LmjQVKwZpuio+G0uJnYji/8gaRk6ccEsGLvqMASEqNSxw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.13.2.tgz",
+      "integrity": "sha512-fvss06Lj/cGS5jGMHantZ/fJ/uQitqrJ2eVn6QWbNhKvcjPUIm1S7Soo3g8d9DPe9n7/HBfpWguvhe+IXyQaCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.13.1.tgz",
-      "integrity": "sha512-w8e1i3G8hB+LxfwqI3yjpRMQ3IVQU/FytLiI8L1zFV1KmmBrrYVZUGPEa9Ey2PP0Eg4EdYiS5Q7ZWx0vxoLwTw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.13.2.tgz",
+      "integrity": "sha512-e93YZgJLxiV0lL9CqQRaGAiht+TOcAkwUqPAD7aujdgwqm5f0hbGBG1afJatQ9lOd8yhj3z/r7Hz+bXJD5Io1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-sui": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-sui": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.13.1.tgz",
-      "integrity": "sha512-kqXsqPlxNusOjvLm2WPCN4kJi85W1OcvJyupkncrKIViVIRi/NCrWi3HtBruAOZY/M+HouHz0LS7Q9ew0o9IeQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.13.2.tgz",
+      "integrity": "sha512-1Lcr16D+nmLrTETpYDaip7ZmwrTRKx+gYEpGiMQY/vZtqDSMrpBifspu43yfM5KfmI4JK+0/nJchMB2g958R2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-sui": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-sui": "1.13.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.13.1.tgz",
-      "integrity": "sha512-/WbVawK0duUmX8gc+sy2P4+sV/omT7O5YcOfEwNYTEpX98szRp7PufU1NaZ2N0prGZ8H6af0cEVvg67oDMIpLg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.13.2.tgz",
+      "integrity": "sha512-3NV/GWLs0O1eruoIMC0H7Utogaf6HuTiBl+/5F1TlLR8nV0KCmAqq8P4iHqqmnuhVKoPcmiu3pdfx9B7aPSYCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.13.1",
-        "@wormhole-foundation/sdk-sui": "1.13.1",
-        "@wormhole-foundation/sdk-sui-core": "1.13.1"
+        "@wormhole-foundation/sdk-connect": "1.13.2",
+        "@wormhole-foundation/sdk-sui": "1.13.2",
+        "@wormhole-foundation/sdk-sui-core": "1.13.2"
       },
       "engines": {
         "node": ">=16"
@@ -2401,9 +2372,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2418,9 +2389,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -2485,9 +2456,9 @@
       }
     },
     "node_modules/binary-layout": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.0.3.tgz",
-      "integrity": "sha512-kpXCSOko4wbQaQswZk4IPcjVZwN77TKZgjMacdoX54EvUHAn/CzJclCt25SUmpXfzFrGovoq3LkPJkMy10bZxQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.2.0.tgz",
+      "integrity": "sha512-K3EHOEEjDLDm3BdT6MXMu/8JQZx7wWMwPlV28ULxHIyW9RFqEp6sQB4Q22bt3u2EBP95H0mWNH6oDz7Cs8iPoA==",
       "license": "Apache-2.0"
     },
     "node_modules/bindings": {
@@ -4187,15 +4158,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-base64": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
@@ -4476,15 +4438,15 @@
       }
     },
     "node_modules/markdown-link-check": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.13.6.tgz",
-      "integrity": "sha512-JiqexKOR+oaBovJ16x/VEN886CzPI48bSGUcKJvnkHVS8xSb9fRJtsdcLwG8+5QQ/V0UZKFmW8JEZFcZbd0BBA==",
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.13.7.tgz",
+      "integrity": "sha512-Btn3HU8s2Uyh1ZfzmyZEkp64zp2+RAjwfQt1u4swq2Xa6w37OW0T2inQZrkSNVxDSa2jSN2YYhw/JkAp5jF1PQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",
         "chalk": "^5.3.0",
-        "commander": "^12.1.0",
+        "commander": "^13.1.0",
         "link-check": "^5.4.0",
         "markdown-link-extractor": "^4.0.2",
         "needle": "^3.3.1",
@@ -4506,6 +4468,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/markdown-link-extractor": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^22.13.9",
-    "markdown-link-check": "^3.13.6",
+    "@types/node": "^22.13.10",
+    "markdown-link-check": "^3.13.7",
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "1.13.1",
+    "@wormhole-foundation/sdk": "1.13.2",
     "sharp": "^0.33.5",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/chains/Movement.json
+++ b/scripts/src/chains/Movement.json
@@ -1,0 +1,23 @@
+{
+	"title": "Movement",
+	"homepage": "https://movementlabs.xyz/",
+	"mainnet": {
+		"name": "Mainnet",
+		"id": "126"
+	},
+	"testnet": {
+		"name": "Testnet",
+		"id": "250"
+	},
+	"explorer": [
+		{
+			"url": "https://explorer.movementlabs.xyz/?network=mainnet",
+			"description": "Movementlabs"
+		}
+	],
+	"devDocs": "https://docs.movementnetwork.xyz/",
+	"faucet": {
+		"url": "https://faucet.devnet.suzuka.movementnetwork.xyz/",
+		"description": "Official Movement Faucet"
+	}
+}


### PR DESCRIPTION
This PR includes a couple minor changes:

- Update SDK version to v1.13.2, which adds Movement as a new chain
- It also adds a fix for the dropdown menus on older versions of Safari