### PR TITLE
Workflow fixes for timeline feature

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -54,7 +54,8 @@ jobs:
       
       - name: Update image paths in Markdown files
         run: |
-          find wormhole-docs -type f -name "*.md" -exec sed -i -e 's|](/docs/|](/wormhole-mkdocs/|g' -e 's|href="/docs/|href="/wormhole-mkdocs/|g' {} \;
+          # Change /docs/ for /wormhole/mkdocs in all .md files inside wormhole-docs and all .md and .json files inside .snippets
+          find wormhole-docs -type f \( -name "*.md" -or \( -path "wormhole-docs/.snippets/*" -a \( -name "*.md" -or -name "*.json" \) \) \) -exec sed -i -e 's|](/docs/|](/wormhole-mkdocs/|g' -e 's|href="/docs/|href="/wormhole-mkdocs/|g' {} \;
           find material-overrides -type f -name "*.html" -exec sed -i -e 's|/docs/|/wormhole-mkdocs/|g' {} \;
       
       - name: Deploy Docs


### PR DESCRIPTION
Timeline introduces snippets as JSONs, which include links. Our current workflow is not considering the `.snippets` folder altogether.