### PR TITLE
enable root-level tocs

### DIFF
--- a/material-overrides/assets/stylesheets/index-page.css
+++ b/material-overrides/assets/stylesheets/index-page.css
@@ -15,10 +15,6 @@
   flex-direction: column;
 }
 
-.md-nav--secondary {
-  display: none;
-}
-
 .md-nav__list .md-nav__item {
   display: block;
 }


### PR DESCRIPTION
Previously, we weren't showing the TOC on the root-level index pages. This PR updates it so that it does appear. This will be helpful now that we have revamped the root-level build and learn index pages and these have several sections.

Goes with: https://github.com/wormhole-foundation/wormhole-docs/pull/333