### PR TITLE
update header styling

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -1,11 +1,32 @@
+:root {
+  --md-header-font: 'Druk', sans-serif;
+  --line-height-90: 90%;
+  --line-height-100: 100%;
+  --header-font-weight: 800;
+  --header-text-style: uppercase;
+}
+
 .md-typeset h1 {
   font-size: 120px;
-  line-height: 108px;
+  font-family: var(--md-header-font);
+  line-height: var(--line-height-90);
+  text-transform: var(--header-text-style);
+  font-weight: var(--header-font-weight);
 }
 
 .md-typeset h2 {
   font-size: 72px;
-  line-height: 72px;
+  font-family: var(--md-header-font);
+  line-height: var(--line-height-100);
+  text-transform: var(--header-text-style);
+  font-weight: var(--header-font-weight);
+}
+
+.md-typeset h3 {
+  font-family: var(--md-header-font);
+  line-height: var(--line-height-100);
+  text-transform: var(--header-text-style);
+  font-weight: var(--header-font-weight);
 }
 
 .md-typeset.md-content__inner a {
@@ -50,13 +71,7 @@
   object-position: center;
 }
 
-.hero h1 {
-  font-size: 120px;
-  margin-bottom: 0;
-}
-
 .hero p {
-  font-size: var(--body-text-size);
   margin: 1em 0 3em;
 }
 
@@ -96,7 +111,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: url(../images/card-bg.svg), #1C1C1C;
+  background: url(../images/card-bg.svg), var(--grey);
   background-size: cover;
   border-radius: 16px;
   padding: 32px 0;
@@ -119,12 +134,11 @@
 }
 
 .product-card > *:nth-child(2) {
-  border-left: 1px solid #FFFFFF26;
+  border-left: 1px solid var(--light-transparent-26);
 }
 
 .product-card h3 {
   font-size: 36px;
-  line-height: 36px;
   font-weight: 700;
   margin: 0;
   align-content: center;
@@ -246,7 +260,6 @@
 
 .feature-card h2 {
   font-size: 60px;
-  line-height: 60px;
   margin: 0;
 }
 
@@ -353,12 +366,10 @@
 
   .md-typeset h2 {
     font-size: 60px;
-    line-height: 60px;
   }
 
   .md-typeset .product-card h3 {
     font-size: 28px;
-    line-height: 28px;
   }
 
   .product-card a {
@@ -381,7 +392,6 @@
   .feature-card h2,
   .start-building-footer h3 {
     font-size: 48px;
-    line-height: 48px;
   }
 }
 
@@ -418,7 +428,6 @@
 
   .hero h1 {
     font-size: 60px;
-    line-height: 60px;
   }
 
   .hero p {
@@ -455,13 +464,11 @@
 
   .md-typeset h2 {
     font-size: 48px;
-    line-height: 48px;
   }
 
   .feature-card h2,
   .start-building-footer h3 {
     font-size: 36px;
-    line-height: 36px;
   }
 
   .start-building-footer {

--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -14,6 +14,7 @@
   --light-transparent-90: rgba(255, 255, 255, 0.9);
   --light-transparent-60: rgba(255, 255, 255, 0.6);
   --light-transparent-40: rgba(255, 255, 255, 0.4);
+  --light-transparent-26: rgba(255, 255, 255, 0.26);
   --light-transparent-20: rgba(255, 255, 255, 0.2);
   --light-transparent-12: rgba(255, 255, 255, 0.12);
   --light-transparent-10: rgba(255, 255, 255, 0.1);
@@ -28,10 +29,10 @@
   --coral-transparent-12: rgba(253, 128, 88, 0.12);
 
   /* Fonts*/
-  --h1-size: 76px;
-  --h2-size: 56px;
-  --h3-size: 48px;
-  --h4-size: 38px;
+  --h1-size: 56px;
+  --h2-size: 48px;
+  --h3-size: 40px;
+  --h4-size: 32px;
 
   --body-l-text-size: 18px;
   --body-text-size: 16px;
@@ -46,11 +47,9 @@
   --caption-size: 11px;
   --label-size: 12px;
 
-  --md-header-font: 'Druk', sans-serif;
-  --h1-h2-line-height: 90%;
-  --h3-h4-line-height: 100%;
-  --header-font-weight: 800;
-  --header-text-style: uppercase;
+  --md-header-font: 'Inter', sans-serif;
+  --header-line-height: 115%;
+  --header-font-weight: 600;
 
   --md-cta-font: 'Druk Wide', sans-serif;
   --md-cta-text-style: uppercase;
@@ -122,18 +121,8 @@
 .md-typeset h3,
 .md-typeset h4 {
   font-family: var(--md-header-font);
-  text-transform: var(--header-text-style);
   font-weight: var(--header-font-weight);
-}
-
-.md-typeset h1,
-.md-typeset h2 {
-  line-height: var(--h1-h2-line-height);
-}
-
-.md-typeset h3,
-.md-typeset h4 {
-  line-height: var(--h3-h4-line-height);
+  line-height: var(--header-line-height);
 }
 
 .md-typeset h1 {
@@ -298,11 +287,9 @@ li.md-nav__item,
 @media screen and (min-width: 76.25em) {
   /* Make the primary section font larger on left nav (i.e., Build, Learn, etc.) */
   .md-nav--lifted > .md-nav__list > .md-nav__item--active > .md-nav__link {
-    font-family: var(--md-header-font);
-    font-size: 26px;
-    font-weight: 700;
-    text-transform: var(--label-text-style);
-    line-height: 33.8px;
+    font-size: 24px;
+    font-weight: 600;
+    line-height: 130%;
     padding: 0 0 0.5em 0.9em;
     margin-left: -0.9em;
     background-color: var(--dark);
@@ -526,7 +513,6 @@ li.md-nav__item,
   box-shadow: none;
   padding: 0.5em 0;
   color: var(--light);
-  text-transform: var(--header-text-style);
   background-color: transparent;
   position: unset;
 }
@@ -622,6 +608,16 @@ li.md-nav__item,
     border-radius: var(--md-border-radius);
     color: #9a9a9a;
     padding: 1em 0.6rem;
+    gap: 8px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .md-nav--secondary .md-nav__title {
+    font-size: 24px;
+    line-height: 130%;
+    font-weight: 600;
+    border-bottom: var(--md-border-width) solid var(--md-border-color);
   }
 
   [dir='ltr'] .md-nav--secondary .md-nav__list[data-md-component='toc'] {
@@ -1334,6 +1330,17 @@ html .md-footer-meta.md-typeset .md-footer-copyright a {
   }
 }
 
+@media screen and (max-width: 30em) {
+  .hs-form {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .md-social {
+    gap: .5em;
+  }
+}
+
 /* 404 page */
 .not-found {
   display: flex;
@@ -1390,10 +1397,9 @@ html .md-footer-meta.md-typeset .md-footer-copyright a {
 .md-typeset .grid.cards > ol > li > p:first-child,
 .md-typeset .grid.cards > ul > li > p:first-child {
   font-family: var(--md-header-font);
-  line-height: var(--h3-h4-line-height);
+  line-height: var(--header-line-height);
   font-weight: var(--header-font-weight);
-  text-transform: var(--header-text-style);
-  font-size: 28px;
+  font-size: 24px;
   display: flex;
   margin-bottom: 0;
 }


### PR DESCRIPTION
This PR updates the header styling based on feedback and design team recommendations. Headers now use the Inter font with a semibold weight, 115% line height, and slightly reduced font sizes.

Note: the home page will still use Druk.