### PR TITLE
Martinh/automate supported chains

### DIFF
--- a/scripts/src/chains/ArbitrumSepolia.json
+++ b/scripts/src/chains/ArbitrumSepolia.json
@@ -1,20 +1,32 @@
 {
-    "title": "Arbitrum Sepolia",
-    "homepage": "https://arbitrum.io/",
-    "devDocs": "https://docs.arbitrum.io/",
-    "faucet": {
-      "url": "https://docs.arbitrum.io/for-devs/dev-tools-and-resources/chain-info#faucets",
-      "token": "ETH",
-      "description": "List of Faucets"
+  "title": "Arbitrum Sepolia",
+  "homepage": "https://arbitrum.io/",
+  "devDocs": "https://docs.arbitrum.io/",
+  "faucet": {
+    "url": "https://docs.arbitrum.io/for-devs/dev-tools-and-resources/chain-info#faucets",
+    "token": "ETH",
+    "description": "List of Faucets"
+  },
+  "testnet": {
+    "name": "Sepolia",
+    "id": "421614"
+  },
+  "explorer": [
+    {
+      "url": "https://sepolia.arbiscan.io/",
+      "description": "Arbitrum Explorer"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
     },
-    "testnet": {
-      "name": "Sepolia",
-      "id": "421614"
-    },
-    "explorer": [
-      {
-        "url": "https://sepolia.arbiscan.io/",
-        "description": "Arbitrum Explorer"
-      }
-    ]
+    "cctp": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
   }
+}

--- a/scripts/src/chains/BaseSepolia.json
+++ b/scripts/src/chains/BaseSepolia.json
@@ -17,5 +17,17 @@
     "url": "https://docs.base.org/docs/tools/network-faucets/",
     "token": "ETH",
     "description": "List of Faucets"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
   }
 }

--- a/scripts/src/chains/HyperEVM.json
+++ b/scripts/src/chains/HyperEVM.json
@@ -1,14 +1,21 @@
 {
-	"title": "HyperEVM",
-	"testnet": { "name": "Testnet", "id": "998" },
-	"homepage": "https://hyperfoundation.org/",
-	"devDocs": "https://hyperliquid.gitbook.io/hyperliquid-docs",
-	"faucet": {
-		"url": "https://app.hyperliquid-testnet.xyz/drip",
-		"token": "mock USDC",
-		"description": "Official Hyperliquid Faucet"
-	},
-	"products": {
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "HyperEVM",
+  "testnet": {
+    "name": "Testnet",
+    "id": "998"
+  },
+  "homepage": "https://hyperfoundation.org/",
+  "devDocs": "https://hyperliquid.gitbook.io/hyperliquid-docs",
+  "faucet": {
+    "url": "https://app.hyperliquid-testnet.xyz/drip",
+    "token": "mock USDC",
+    "description": "Official Hyperliquid Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/Ink.json
+++ b/scripts/src/chains/Ink.json
@@ -1,24 +1,32 @@
 {
-	"title": "Ink",
-	"testnet": {
-		"name": "Testnet",
-		"id": "763373"
-	},
-	"homepage": "https://inkonchain.com/",
-	"devDocs": "https://docs.inkonchain.com/",
-	"faucet": {
-		"url": "https://inkonchain.com/faucet",
-		"token": "ETH",
-		"description": "Official Ink Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://explorer-sepolia.inkonchain.com/",
-			"description": "Ink Sepolia Explorer"
-		}
-	],
-	"products": {
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Ink",
+  "testnet": {
+    "name": "Testnet",
+    "id": "763373"
+  },
+  "homepage": "https://inkonchain.com/",
+  "devDocs": "https://docs.inkonchain.com/",
+  "faucet": {
+    "url": "https://inkonchain.com/faucet",
+    "token": "ETH",
+    "description": "Official Ink Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://explorer-sepolia.inkonchain.com/",
+      "description": "Ink Sepolia Explorer"
+    }
+  ],
+  "products": {
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/Mezo.json
+++ b/scripts/src/chains/Mezo.json
@@ -1,19 +1,27 @@
 {
-	"title": "Mezo",
-	"homepage": "https://mezo.org/",
-	"testnet": {
-		"name": "Testnet",
-		"id": "31611"
-	},
-	"devDocs": "https://mezo.org/docs/developers/",
-	"explorer": [
-		{
-			"url": "https://explorer.test.mezo.org/",
-			"description": "Mezo Testnet Explorer"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": false, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "Mezo",
+  "homepage": "https://mezo.org/",
+  "testnet": {
+    "name": "Testnet",
+    "id": "31611"
+  },
+  "devDocs": "https://mezo.org/docs/developers/",
+  "explorer": [
+    {
+      "url": "https://explorer.test.mezo.org/",
+      "description": "Mezo Testnet Explorer"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/Monad.json
+++ b/scripts/src/chains/Monad.json
@@ -1,20 +1,27 @@
 {
-	"title": "Monad",
-	"homepage": "https://www.monad.xyz/",
-	"testnet": { "name": "Testnet", "id": "10143" },
-	"devDocs": "https://docs.monad.xyz/",
-	"faucet": {
-		"url": "https://testnet.monad.xyz/",
-		"token": "MON",
-		"description": "Official Monad Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://testnet.monadexplorer.com/",
-			"description": "Monad Testnet Explorer"
-		}
-	],
-	"products": {
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "Monad",
+  "homepage": "https://www.monad.xyz/",
+  "testnet": {
+    "name": "Testnet",
+    "id": "10143"
+  },
+  "devDocs": "https://docs.monad.xyz/",
+  "faucet": {
+    "url": "https://testnet.monad.xyz/",
+    "token": "MON",
+    "description": "Official Monad Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://testnet.monadexplorer.com/",
+      "description": "Monad Testnet Explorer"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/Noble.json
+++ b/scripts/src/chains/Noble.json
@@ -19,5 +19,6 @@
     {
       "url": "https://docs.noble.xyz/network/resources"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/OptimismSepolia.json
+++ b/scripts/src/chains/OptimismSepolia.json
@@ -1,25 +1,37 @@
 {
-    "title": "Optimism Sepolia",
-    "testnet": {
-      "name": "Optimism Sepolia",
-      "id": "11155420"
+  "title": "Optimism Sepolia",
+  "testnet": {
+    "name": "Optimism Sepolia",
+    "id": "11155420"
+  },
+  "homepage": "https://www.optimism.io/",
+  "devDocs": "https://docs.optimism.io/",
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "explorer": [
+    {
+      "url": "https://sepolia-optimistic.etherscan.io/",
+      "description": "OP Sepolia Etherscan"
+    }
+  ],
+  "faucet": {
+    "url": "https://console.optimism.io/faucet",
+    "token": "ETH",
+    "description": "Superchain Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
     },
-    "homepage": "https://www.optimism.io/",
-    "devDocs": "https://docs.optimism.io/",
-    "contractSource": "ethereum/contracts/bridge/Bridge.sol",
-    "finality": {
-      "instant": 200,
-      "otherwise": "finalized"
-    },
-    "explorer": [
-      {
-        "url": "https://sepolia-optimistic.etherscan.io/",
-        "description": "OP Sepolia Etherscan"
-      }
-    ],
-    "faucet": {
-      "url": "https://console.optimism.io/faucet",
-      "token": "ETH",
-      "description": "Superchain Faucet"
+    "cctp": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
     }
   }
+}

--- a/scripts/src/chains/PolygonSepolia.json
+++ b/scripts/src/chains/PolygonSepolia.json
@@ -1,26 +1,33 @@
 {
-    "title": "Polygon Amoy",
-    "homepage": "https://polygon.technology/",
-    "testnet": {
-      "name": "Amoy",
-      "id": "80002"
-    },
-    "contractSource": "ethereum/contracts/bridge/Bridge.sol",
-    "finality": {
-      "details": "https://docs.polygon.technology/pos/architecture/heimdall/checkpoints/",
-      "instant": 200,
-      "otherwise": "finalized"
-    },
-    "devDocs": "https://docs.polygon.technology/",
-    "faucet": {
-      "url": "https://faucet.polygon.technology/",
-      "token": "POL",
-      "description": "Official Polygon Faucet"
-    },
-    "explorer": [
-      {
-        "url": "https://amoy.polygonscan.com/",
-        "description": "Polygonscan"
-      }
-    ]
+  "title": "Polygon Amoy",
+  "homepage": "https://polygon.technology/",
+  "testnet": {
+    "name": "Amoy",
+    "id": "80002"
+  },
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "details": "https://docs.polygon.technology/pos/architecture/heimdall/checkpoints/",
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.polygon.technology/",
+  "faucet": {
+    "url": "https://faucet.polygon.technology/",
+    "token": "POL",
+    "description": "Official Polygon Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://amoy.polygonscan.com/",
+      "description": "Polygonscan"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
   }
+}

--- a/scripts/src/chains/Worldchain.json
+++ b/scripts/src/chains/Worldchain.json
@@ -1,28 +1,40 @@
 {
-	"title": "World Chain",
-	"testnet": {
-		"name": "Testnet",
-		"id": "4801"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "480"
-	},
-	"homepage": "https://world.org/world-chain",
-	"devDocs": "https://docs.world.org/",
-	"faucet": {
-		"url": "https://www.alchemy.com/faucets/world-chain-sepolia",
-		"token": "ETH",
-		"description": "Alchemy Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://docs.world.org/world-chain/providers/explorers"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "World Chain",
+  "testnet": {
+    "name": "Testnet",
+    "id": "4801"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "480"
+  },
+  "homepage": "https://world.org/world-chain",
+  "devDocs": "https://docs.world.org/",
+  "faucet": {
+    "url": "https://www.alchemy.com/faucets/world-chain-sepolia",
+    "token": "ETH",
+    "description": "Alchemy Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://docs.world.org/world-chain/providers/explorers"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/acala.json
+++ b/scripts/src/chains/acala.json
@@ -1,35 +1,39 @@
 {
-	"homepage": "https://acala.network/",
-	"title": "Acala",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "787"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "597"
-	},
-	"explorer": [
-		{
-			"url": "https://acala.subscan.io/"
-		},
-		{
-			"url": "https://blockscout.acala.network/"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://evmdocs.acala.network/",
-	"faucet": {
-		"url": "https://discord.gg/5JJgXKSznc",
-		"token": "ACA",
-		"description": "Discord Faucet"
-	},
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "homepage": "https://acala.network/",
+  "title": "Acala",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "787"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "597"
+  },
+  "explorer": [
+    {
+      "url": "https://acala.subscan.io/"
+    },
+    {
+      "url": "https://blockscout.acala.network/"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://evmdocs.acala.network/",
+  "faucet": {
+    "url": "https://discord.gg/5JJgXKSznc",
+    "token": "ACA",
+    "description": "Discord Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/algorand.json
+++ b/scripts/src/chains/algorand.json
@@ -1,36 +1,40 @@
 {
-	"homepage": "https://algorand.com",
-	"title": "Algorand",
-	"mainnet": {
-		"id": "mainnet-v1.0",
-		"name": "Mainnet"
-	},
-	"testnet": {
-		"id": "testnet-v1.0",
-		"name": "Testnet"
-	},
-	"explorer": [
-		{
-			"url": "https://allo.info/",
-			"description": "Allo"
-		},
-		{
-			"url": "https://explorer.perawallet.app/",
-			"description": "Pera Explorer"
-		}
-	],
-	"contractSource": "algorand/wormhole_core.py",
-	"finality": {
-		"finalized": 0,
-		"details": "https://developer.algorand.org/docs/get-started/basics/why_algorand/#finality"
-	},
-	"devDocs": "https://developer.algorand.org",
-	"faucet": {
-		"url": "https://bank.testnet.algorand.network/",
-		"token": "ALGO",
-		"description": "Official Algorand Faucet"
-	},
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "homepage": "https://algorand.com",
+  "title": "Algorand",
+  "mainnet": {
+    "id": "mainnet-v1.0",
+    "name": "Mainnet"
+  },
+  "testnet": {
+    "id": "testnet-v1.0",
+    "name": "Testnet"
+  },
+  "explorer": [
+    {
+      "url": "https://allo.info/",
+      "description": "Allo"
+    },
+    {
+      "url": "https://explorer.perawallet.app/",
+      "description": "Pera Explorer"
+    }
+  ],
+  "contractSource": "algorand/wormhole_core.py",
+  "finality": {
+    "finalized": 0,
+    "details": "https://developer.algorand.org/docs/get-started/basics/why_algorand/#finality"
+  },
+  "devDocs": "https://developer.algorand.org",
+  "faucet": {
+    "url": "https://bank.testnet.algorand.network/",
+    "token": "ALGO",
+    "description": "Official Algorand Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/aptos.json
+++ b/scripts/src/chains/aptos.json
@@ -1,43 +1,51 @@
 {
-	"title": "Aptos",
-	"homepage": "https://aptosfoundation.org/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "1"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "2"
-	},
-	"explorer": [
-		{
-			"url": "https://explorer.aptoslabs.com/",
-			"description": "Aptos Explorer"
-		},
-		{
-			"url": "https://aptoscan.com/",
-			"description": "AptoScan"
-		}
-	],
-	"examples": [
-		{
-			"url": "https://github.com/wormhole-foundation/wormhole/tree/main/aptos/examples",
-			"description": "Message passing on Aptos"
-		}
-	],
-	"contractSource": "aptos/wormhole/sources/wormhole.move",
-	"finality": {
-		"details": "https://aptos.dev/en/network/glossary#byzantine-fault-tolerance-bft",
-		"finalized": 0
-	},
-	"devDocs": "https://aptos.dev/",
-	"faucet": {
-		"url": "https://www.aptosfaucet.com/",
-		"token": "APT",
-		"description": "Official Aptos Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Aptos",
+  "homepage": "https://aptosfoundation.org/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "1"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "2"
+  },
+  "explorer": [
+    {
+      "url": "https://explorer.aptoslabs.com/",
+      "description": "Aptos Explorer"
+    },
+    {
+      "url": "https://aptoscan.com/",
+      "description": "AptoScan"
+    }
+  ],
+  "examples": [
+    {
+      "url": "https://github.com/wormhole-foundation/wormhole/tree/main/aptos/examples",
+      "description": "Message passing on Aptos"
+    }
+  ],
+  "contractSource": "aptos/wormhole/sources/wormhole.move",
+  "finality": {
+    "details": "https://aptos.dev/en/network/glossary#byzantine-fault-tolerance-bft",
+    "finalized": 0
+  },
+  "devDocs": "https://aptos.dev/",
+  "faucet": {
+    "url": "https://www.aptosfaucet.com/",
+    "token": "APT",
+    "description": "Official Aptos Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/arbitrum.json
+++ b/scripts/src/chains/arbitrum.json
@@ -1,33 +1,57 @@
 {
-	"title": "Arbitrum",
-	"homepage": "https://arbitrum.io/",
-	"mainnet": {
-		"name": "Arbitrum One",
-		"id": "42161"
-	},
-	"testnet": {
-		"name": "Goerli",
-		"id": "421613"
-	},
-	"explorer": [
-		{
-			"url": "https://arbiscan.io/",
-			"description": "Arbitrum Explorer"
-		}
-	],
-	"finality": {
-		"details": "https://docs.arbitrum.io/how-arbitrum-works/transaction-lifecycle",
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.arbitrum.io/",
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"cctp": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Arbitrum",
+  "homepage": "https://arbitrum.io/",
+  "mainnet": {
+    "name": "Arbitrum One",
+    "id": "42161"
+  },
+  "testnet": {
+    "name": "Goerli",
+    "id": "421613"
+  },
+  "explorer": [
+    {
+      "url": "https://arbiscan.io/",
+      "description": "Arbitrum Explorer"
+    }
+  ],
+  "finality": {
+    "details": "https://docs.arbitrum.io/how-arbitrum-works/transaction-lifecycle",
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.arbitrum.io/",
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/avalanche.json
+++ b/scripts/src/chains/avalanche.json
@@ -1,41 +1,65 @@
 {
-	"homepage": "https://www.avax.network/",
-	"title": "Avalanche",
-	"mainnet": {
-		"name": "C-Chain",
-		"id": "43114"
-	},
-	"testnet": {
-		"name": "Fuji",
-		"id": "43113"
-	},
-	"explorer": [
-		{
-			"url": "https://snowtrace.io/",
-			"description": "C-Chain Block Explorer"
-		},
-		{
-			"url": "https://subnets.avax.network/"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized",
-		"details": "https://docs.avax.network/dapps/advanced-tutorials/exchange-integration#determining-finality"
-	},
-	"devDocs": "https://docs.avax.network/",
-	"faucet": {
-		"url": "https://core.app/tools/testnet-faucet/?subnet=c&token=c",
-		"token": "AVAX",
-		"description": "Official Avalanche Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"cctp": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "homepage": "https://www.avax.network/",
+  "title": "Avalanche",
+  "mainnet": {
+    "name": "C-Chain",
+    "id": "43114"
+  },
+  "testnet": {
+    "name": "Fuji",
+    "id": "43113"
+  },
+  "explorer": [
+    {
+      "url": "https://snowtrace.io/",
+      "description": "C-Chain Block Explorer"
+    },
+    {
+      "url": "https://subnets.avax.network/"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized",
+    "details": "https://docs.avax.network/dapps/advanced-tutorials/exchange-integration#determining-finality"
+  },
+  "devDocs": "https://docs.avax.network/",
+  "faucet": {
+    "url": "https://core.app/tools/testnet-faucet/?subnet=c&token=c",
+    "token": "AVAX",
+    "description": "Official Avalanche Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/base.json
+++ b/scripts/src/chains/base.json
@@ -1,37 +1,61 @@
 {
-	"title": "Base",
-	"homepage": "https://base.org/",
-	"mainnet": {
-		"name": "Base",
-		"id": "8453"
-	},
-	"testnet": {
-		"name": "Base Goerli",
-		"id": "84531"
-	},
-	"explorer": [
-		{
-			"url": "https://goerli.basescan.org/",
-			"description": "Etherscan"
-		},
-		{
-			"url": "https://base-goerli.blockscout.com/",
-			"description": "Blockscout"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.base.org/",
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"cctp": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Base",
+  "homepage": "https://base.org/",
+  "mainnet": {
+    "name": "Base",
+    "id": "8453"
+  },
+  "testnet": {
+    "name": "Base Goerli",
+    "id": "84531"
+  },
+  "explorer": [
+    {
+      "url": "https://goerli.basescan.org/",
+      "description": "Etherscan"
+    },
+    {
+      "url": "https://base-goerli.blockscout.com/",
+      "description": "Blockscout"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.base.org/",
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/berachain.json
+++ b/scripts/src/chains/berachain.json
@@ -1,29 +1,41 @@
 {
-	"title": "Berachain",
-	"testnet": {
-		"name": "Testnet",
-		"id": "80084"
-	},
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"homepage": "https://www.berachain.com/",
-	"devDocs": "https://docs.berachain.com/",
-	"faucet": {
-		"url": "https://bartio.faucet.berachain.com/",
-		"token": "BERA",
-		"description": "Official Berachain Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://bartio.beratrail.io/",
-			"description": "Beratrail"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": false, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Berachain",
+  "testnet": {
+    "name": "Testnet",
+    "id": "80084"
+  },
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "homepage": "https://www.berachain.com/",
+  "devDocs": "https://docs.berachain.com/",
+  "faucet": {
+    "url": "https://bartio.faucet.berachain.com/",
+    "token": "BERA",
+    "description": "Official Berachain Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://bartio.beratrail.io/",
+      "description": "Beratrail"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/blast.json
+++ b/scripts/src/chains/blast.json
@@ -1,33 +1,45 @@
 {
-	"title": "Blast",
-	"testnet": {
-		"name": "Testnet",
-		"id": "168587773"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "81457"
-	},
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.blast.io/about-blast",
-	"faucet": {
-		"url": "https://docs.blast.io/tools/faucets#faucets",
-		"token": "ETH",
-		"description": "List of Faucets"
-	},
-	"homepage": "https://blast.io/",
-	"explorer": [
-		{
-			"url": "https://docs.blast.io/tools/block-explorers#block-explorers"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Blast",
+  "testnet": {
+    "name": "Testnet",
+    "id": "168587773"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "81457"
+  },
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.blast.io/about-blast",
+  "faucet": {
+    "url": "https://docs.blast.io/tools/faucets#faucets",
+    "token": "ETH",
+    "description": "List of Faucets"
+  },
+  "homepage": "https://blast.io/",
+  "explorer": [
+    {
+      "url": "https://docs.blast.io/tools/block-explorers#block-explorers"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/bsc.json
+++ b/scripts/src/chains/bsc.json
@@ -1,35 +1,48 @@
 {
-	"title": "BNB Smart Chain",
-	"homepage": "https://www.bnbchain.org/en/smartChain",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "56"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "97"
-	},
-	"explorer": [
-		{
-			"url": "https://bscscan.com/",
-			"description": "BscScan"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized",
-		"safe": 201,
-		"details": "https://docs.bnbchain.org/bnb-smart-chain/introduction/?h=finality"
-	},
-	"devDocs": "https://docs.bnbchain.org/",
-	"faucet": {
-		"url": "https://testnet.binance.org/faucet-smart/",
-		"token": "BNB",
-		"description": "Official BNB Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "BNB Smart Chain",
+  "homepage": "https://www.bnbchain.org/en/smartChain",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "56"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "97"
+  },
+  "explorer": [
+    {
+      "url": "https://bscscan.com/",
+      "description": "BscScan"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized",
+    "safe": 201,
+    "details": "https://docs.bnbchain.org/bnb-smart-chain/introduction/?h=finality"
+  },
+  "devDocs": "https://docs.bnbchain.org/",
+  "faucet": {
+    "url": "https://testnet.binance.org/faucet-smart/",
+    "token": "BNB",
+    "description": "Official BNB Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/celestia.json
+++ b/scripts/src/chains/celestia.json
@@ -19,5 +19,6 @@
     {
       "url": "https://docs.celestia.org/how-to-guides/mocha-testnet#explorers"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/celo.json
+++ b/scripts/src/chains/celo.json
@@ -1,36 +1,48 @@
 {
-	"homepage": "https://celo.org/",
-	"title": "Celo",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "42220"
-	},
-	"testnet": {
-		"name": "Alfajores",
-		"id": "44787"
-	},
-	"explorer": [
-		{
-			"url": "https://explorer.celo.org/mainnet/"
-		},
-		{
-			"url": "https://celoscan.io/"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.celo.org/",
-	"faucet": {
-		"url": "https://faucet.celo.org/alfajores",
-		"token": "CELO",
-		"description": "Official Celo Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "homepage": "https://celo.org/",
+  "title": "Celo",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "42220"
+  },
+  "testnet": {
+    "name": "Alfajores",
+    "id": "44787"
+  },
+  "explorer": [
+    {
+      "url": "https://explorer.celo.org/mainnet/"
+    },
+    {
+      "url": "https://celoscan.io/"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.celo.org/",
+  "faucet": {
+    "url": "https://faucet.celo.org/alfajores",
+    "token": "CELO",
+    "description": "Official Celo Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/cosmoshub.json
+++ b/scripts/src/chains/cosmoshub.json
@@ -19,5 +19,6 @@
     {
       "url": "https://hub.cosmos.network/main/hub-tutorials/join-mainnet#explorers"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/dymension.json
+++ b/scripts/src/chains/dymension.json
@@ -10,5 +10,6 @@
       "url": "https://www.mintscan.io/dymension"
     }
   ],
-  "devDocs": "https://docs.dymension.xyz/"
+  "devDocs": "https://docs.dymension.xyz/",
+  "products": {}
 }

--- a/scripts/src/chains/ethereum.json
+++ b/scripts/src/chains/ethereum.json
@@ -1,34 +1,60 @@
 {
-	"homepage": "https://ethereum.org/",
-	"title": "Ethereum",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "1"
-	},
-	"testnet": {
-		"name": "Goerli",
-		"id": "5"
-	},
-	"notes": ["Deployed contracts are also available on the [Sepolia](#sepolia) testnet."],
-	"devDocs": "https://ethereum.org/en/developers/docs/",
-	"explorer": [
-		{
-			"url": "https://etherscan.io/"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"details": "https://www.alchemy.com/overviews/ethereum-commitment-levels",
-		"instant": 200,
-		"otherwise": "finalized",
-		"safe": 201
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": true },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": true },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true },
-		"cctp": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "homepage": "https://ethereum.org/",
+  "title": "Ethereum",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "1"
+  },
+  "testnet": {
+    "name": "Goerli",
+    "id": "5"
+  },
+  "notes": [
+    "Deployed contracts are also available on the [Sepolia](#sepolia) testnet."
+  ],
+  "devDocs": "https://ethereum.org/en/developers/docs/",
+  "explorer": [
+    {
+      "url": "https://etherscan.io/"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "details": "https://www.alchemy.com/overviews/ethereum-commitment-levels",
+    "instant": 200,
+    "otherwise": "finalized",
+    "safe": 201
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/evmos.json
+++ b/scripts/src/chains/evmos.json
@@ -19,5 +19,6 @@
     "url": "https://faucet.evmos.dev/",
     "token": "TEVMOS",
     "description": "Official Evmos Faucet"
-  }
+  },
+  "products": {}
 }

--- a/scripts/src/chains/fantom.json
+++ b/scripts/src/chains/fantom.json
@@ -1,34 +1,50 @@
 {
-	"homepage": "https://fantom.foundation/",
-	"title": "Fantom",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "250"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "4002"
-	},
-	"explorer": [
-		{
-			"url": "https://ftmscan.com/"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.fantom.foundation/",
-	"faucet": {
-		"url": "https://faucet.fantom.network/",
-		"token": "FTM",
-		"description": "Official Fantom Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "homepage": "https://fantom.foundation/",
+  "title": "Fantom",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "250"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "4002"
+  },
+  "explorer": [
+    {
+      "url": "https://ftmscan.com/"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.fantom.foundation/",
+  "faucet": {
+    "url": "https://faucet.fantom.network/",
+    "token": "FTM",
+    "description": "Official Fantom Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/gnosis.json
+++ b/scripts/src/chains/gnosis.json
@@ -1,28 +1,32 @@
 {
-	"title": "Gnosis",
-	"homepage": "https://www.gnosis.io/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "100"
-	},
-	"testnet": {
-		"name": "Chiado",
-		"id": "10200"
-	},
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"devDocs": "https://docs.gnosischain.com/",
-	"faucet": {
-		"url": "https://faucet.gnosischain.com/",
-		"token": "xDAI",
-		"description": "Official Gnosis Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://gnosisscan.io/",
-			"description": "GnosisScan"
-		}
-	],
-	"products": {
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Gnosis",
+  "homepage": "https://www.gnosis.io/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "100"
+  },
+  "testnet": {
+    "name": "Chiado",
+    "id": "10200"
+  },
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "devDocs": "https://docs.gnosischain.com/",
+  "faucet": {
+    "url": "https://faucet.gnosischain.com/",
+    "token": "xDAI",
+    "description": "Official Gnosis Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://gnosisscan.io/",
+      "description": "GnosisScan"
+    }
+  ],
+  "products": {
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/holesky.json
+++ b/scripts/src/chains/holesky.json
@@ -19,5 +19,12 @@
     "url": "https://www.alchemy.com/faucets/ethereum-holesky",
     "token": "ETH",
     "description": "Alchemy Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
   }
 }

--- a/scripts/src/chains/injective.json
+++ b/scripts/src/chains/injective.json
@@ -1,41 +1,45 @@
 {
-	"title": "Injective",
-	"homepage": "https://injective.com/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "injective-1"
-	},
-	"explorer": [
-		{
-			"url": "https://explorer.injective.network/",
-			"description": "Injective Explorer"
-		},
-		{
-			"url": "https://testnet.explorer.injective.network/",
-			"description": "Injective Testnet Explorer"
-		}
-	],
-	"testnet": {
-		"name": "Testnet",
-		"id": "injective-888"
-	},
-	"devDocs": "https://docs.injective.network/",
-	"faucet": {
-		"url": "https://testnet.faucet.injective.network/",
-		"token": "INJ",
-		"description": "Official Injective Faucet"
-	},
-	"additionaLinks": [
-		{
-			"url": "https://docs.ts.injective.network/",
-			"description": "Injective Typescript SDK docs"
-		},
-		{
-			"url": "https://docs.trading.injective.network/",
-			"description": "Injective trading docs"
-		}
-	],
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Injective",
+  "homepage": "https://injective.com/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "injective-1"
+  },
+  "explorer": [
+    {
+      "url": "https://explorer.injective.network/",
+      "description": "Injective Explorer"
+    },
+    {
+      "url": "https://testnet.explorer.injective.network/",
+      "description": "Injective Testnet Explorer"
+    }
+  ],
+  "testnet": {
+    "name": "Testnet",
+    "id": "injective-888"
+  },
+  "devDocs": "https://docs.injective.network/",
+  "faucet": {
+    "url": "https://testnet.faucet.injective.network/",
+    "token": "INJ",
+    "description": "Official Injective Faucet"
+  },
+  "additionaLinks": [
+    {
+      "url": "https://docs.ts.injective.network/",
+      "description": "Injective Typescript SDK docs"
+    },
+    {
+      "url": "https://docs.trading.injective.network/",
+      "description": "Injective trading docs"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/karura.json
+++ b/scripts/src/chains/karura.json
@@ -1,29 +1,37 @@
 {
-	"title": "Karura",
-	"homepage": "https://acala.network/karura",
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "686"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "596"
-	},
-	"finality": {
-		"details": "https://wiki.polkadot.network/docs/learn-consensus",
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://evmdocs.acala.network/",
-	"faucet": {
-		"url": "https://discord.gg/5JJgXKSznc",
-		"token": "ACA",
-		"description": "Discord Faucet"
-	},
-	"products": {
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Karura",
+  "homepage": "https://acala.network/karura",
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "686"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "596"
+  },
+  "finality": {
+    "details": "https://wiki.polkadot.network/docs/learn-consensus",
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://evmdocs.acala.network/",
+  "faucet": {
+    "url": "https://discord.gg/5JJgXKSznc",
+    "token": "ACA",
+    "description": "Discord Faucet"
+  },
+  "products": {
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/klaytn.json
+++ b/scripts/src/chains/klaytn.json
@@ -29,5 +29,12 @@
     "url": "https://faucet.kaia.io",
     "token": "KAIA",
     "description": "Official Kaia Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
   }
 }

--- a/scripts/src/chains/kujira.json
+++ b/scripts/src/chains/kujira.json
@@ -20,5 +20,6 @@
   "testnet": {
     "name": "Testnet",
     "id": "harpoon-4"
-  }
+  },
+  "products": {}
 }

--- a/scripts/src/chains/linea.json
+++ b/scripts/src/chains/linea.json
@@ -1,30 +1,34 @@
 {
-	"title": "Linea",
-	"homepage": "https://linea.build/",
-	"devDocs": "https://docs.linea.build/",
-	"faucet": {
-		"url": "https://docs.linea.build/get-started/how-to/get-testnet-eth",
-		"token": "ETH",
-		"description": "List of Faucets"
-	},
-	"explorer": [
-		{
-			"url": "https://docs.linea.build/get-started/build/block-explorers"
-		}
-	],
-	"testnet": {
-		"name": "Testnet",
-		"id": "59141"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "59144"
-	},
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"products": {
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "Linea",
+  "homepage": "https://linea.build/",
+  "devDocs": "https://docs.linea.build/",
+  "faucet": {
+    "url": "https://docs.linea.build/get-started/how-to/get-testnet-eth",
+    "token": "ETH",
+    "description": "List of Faucets"
+  },
+  "explorer": [
+    {
+      "url": "https://docs.linea.build/get-started/build/block-explorers"
+    }
+  ],
+  "testnet": {
+    "name": "Testnet",
+    "id": "59141"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "59144"
+  },
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/mantle.json
+++ b/scripts/src/chains/mantle.json
@@ -1,34 +1,46 @@
 {
-	"title": "Mantle",
-	"homepage": "https://www.mantle.xyz/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "5000"
-	},
-	"testnet": {
-		"name": "Sepolia",
-		"id": "5003"
-	},
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.mantle.xyz/network/introduction/overview",
-	"faucet": {
-		"url": "https://faucet.sepolia.mantle.xyz/",
-		"token": "MNT",
-		"description": "Official Mantle Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://mantlescan.xyz/",
-			"description": "Mantlescan"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Mantle",
+  "homepage": "https://www.mantle.xyz/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "5000"
+  },
+  "testnet": {
+    "name": "Sepolia",
+    "id": "5003"
+  },
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.mantle.xyz/network/introduction/overview",
+  "faucet": {
+    "url": "https://faucet.sepolia.mantle.xyz/",
+    "token": "MNT",
+    "description": "Official Mantle Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://mantlescan.xyz/",
+      "description": "Mantlescan"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/moonbeam.json
+++ b/scripts/src/chains/moonbeam.json
@@ -1,37 +1,53 @@
 {
-	"title": "Moonbeam",
-	"homepage": "https://moonbeam.network/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "1284"
-	},
-	"testnet": {
-		"name": "Moonbase-Alphanet",
-		"id": "1287"
-	},
-	"explorer": [
-		{
-			"url": "https://moonscan.io/",
-			"description": "Moonscan"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized",
-		"details": "https://docs.moonbeam.network/builders/ethereum/json-rpc/moonbeam-custom-api/#finality-rpc-endpoints"
-	},
-	"devDocs": "https://docs.moonbeam.network/",
-	"faucet": {
-		"url": "https://faucet.moonbeam.network/",
-		"token": "DEV",
-		"description": "Official Moonbeam Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Moonbeam",
+  "homepage": "https://moonbeam.network/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "1284"
+  },
+  "testnet": {
+    "name": "Moonbase-Alphanet",
+    "id": "1287"
+  },
+  "explorer": [
+    {
+      "url": "https://moonscan.io/",
+      "description": "Moonscan"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized",
+    "details": "https://docs.moonbeam.network/builders/ethereum/json-rpc/moonbeam-custom-api/#finality-rpc-endpoints"
+  },
+  "devDocs": "https://docs.moonbeam.network/",
+  "faucet": {
+    "url": "https://faucet.moonbeam.network/",
+    "token": "DEV",
+    "description": "Official Moonbeam Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/near.json
+++ b/scripts/src/chains/near.json
@@ -1,30 +1,34 @@
 {
-	"title": "NEAR",
-	"homepage": "https://near.org/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "mainnet"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "testnet"
-	},
-	"devDocs": "https://docs.near.org/",
-	"explorer": [
-		{
-			"url": "https://nearblocks.io/"
-		}
-	],
-	"finality": {
-		"details": "https://nomicon.io/ChainSpec/Consensus",
-		"finalized": 0
-	},
-	"faucet": {
-		"url": "https://near-faucet.io/",
-		"token": "NEAR",
-		"description": "Official NEAR Faucet"
-	},
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "NEAR",
+  "homepage": "https://near.org/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "mainnet"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "testnet"
+  },
+  "devDocs": "https://docs.near.org/",
+  "explorer": [
+    {
+      "url": "https://nearblocks.io/"
+    }
+  ],
+  "finality": {
+    "details": "https://nomicon.io/ChainSpec/Consensus",
+    "finalized": 0
+  },
+  "faucet": {
+    "url": "https://near-faucet.io/",
+    "token": "NEAR",
+    "description": "Official NEAR Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/neon.json
+++ b/scripts/src/chains/neon.json
@@ -1,28 +1,32 @@
 {
-	"title": "Neon",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "245022934"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "245022940"
-	},
-	"homepage": "https://neonevm.org/",
-	"devDocs": "https://neonevm.org/docs/",
-	"faucet": {
-		"url": "https://neonfaucet.org/",
-		"token": "NEON",
-		"description": "Official Neon Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://neonscan.org/",
-			"description": "Neonscan"
-		}
-	],
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"products": {
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "Neon",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "245022934"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "245022940"
+  },
+  "homepage": "https://neonevm.org/",
+  "devDocs": "https://neonevm.org/docs/",
+  "faucet": {
+    "url": "https://neonfaucet.org/",
+    "token": "NEON",
+    "description": "Official Neon Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://neonscan.org/",
+      "description": "Neonscan"
+    }
+  ],
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/neutron.json
+++ b/scripts/src/chains/neutron.json
@@ -19,5 +19,6 @@
     {
       "url": "https://docs.neutron.org/neutron/faq#where-is-the-block-explorer"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/oasis.json
+++ b/scripts/src/chains/oasis.json
@@ -1,32 +1,40 @@
 {
-	"title": "Oasis",
-	"homepage": "https://oasisprotocol.org/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "42262"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "42261"
-	},
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.oasis.io/",
-	"faucet": {
-		"url": "https://faucet.testnet.oasis.io/",
-		"token": "TEST",
-		"description": "Official Oasis Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://docs.oasis.io/dapp/cipher/#block-explorers"
-		}
-	],
-	"products": {
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Oasis",
+  "homepage": "https://oasisprotocol.org/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "42262"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "42261"
+  },
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.oasis.io/",
+  "faucet": {
+    "url": "https://faucet.testnet.oasis.io/",
+    "token": "TEST",
+    "description": "Official Oasis Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://docs.oasis.io/dapp/cipher/#block-explorers"
+    }
+  ],
+  "products": {
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/optimism.json
+++ b/scripts/src/chains/optimism.json
@@ -1,33 +1,57 @@
 {
-	"title": "Optimism",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "10"
-	},
-	"testnet": {
-		"name": "Optimism Sepolia",
-		"id": "11155420"
-	},
-	"homepage": "https://www.optimism.io/",
-	"devDocs": "https://docs.optimism.io/",
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"explorer": [
-		{
-			"url": "https://optimistic.etherscan.io/",
-			"description": "OP Mainnet Etherscan"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"cctp": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Optimism",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "10"
+  },
+  "testnet": {
+    "name": "Optimism Sepolia",
+    "id": "11155420"
+  },
+  "homepage": "https://www.optimism.io/",
+  "devDocs": "https://docs.optimism.io/",
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "explorer": [
+    {
+      "url": "https://optimistic.etherscan.io/",
+      "description": "OP Mainnet Etherscan"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/osmosis.json
+++ b/scripts/src/chains/osmosis.json
@@ -1,26 +1,30 @@
 {
-	"title": "Osmosis",
-	"homepage": "https://osmosis.zone/",
-	"devDocs": "https://docs.osmosis.zone/",
-	"faucet": {
-		"url": "https://faucet.testnet.osmosis.zone/",
-		"token": "OSMO",
-		"description": "Official Osmosis Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://docs.osmosis.zone/overview/endpoints#explorers"
-		}
-	],
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "osmosis-1"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "osmo-test-5"
-	},
-	"products": {
-		"connect": { "mainnet": false, "testnet": false, "devnet": true }
-	}
+  "title": "Osmosis",
+  "homepage": "https://osmosis.zone/",
+  "devDocs": "https://docs.osmosis.zone/",
+  "faucet": {
+    "url": "https://faucet.testnet.osmosis.zone/",
+    "token": "OSMO",
+    "description": "Official Osmosis Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://docs.osmosis.zone/overview/endpoints#explorers"
+    }
+  ],
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "osmosis-1"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "osmo-test-5"
+  },
+  "products": {
+    "connect": {
+      "mainnet": false,
+      "testnet": false,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/polygon.json
+++ b/scripts/src/chains/polygon.json
@@ -1,33 +1,57 @@
 {
-	"title": "Polygon",
-	"homepage": "https://polygon.technology/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "137"
-	},
-	"testnet": {
-		"name": "Amoy",
-		"id": "80002"
-	},
-	"contractSource": "ethereum/contracts/bridge/Bridge.sol",
-	"finality": {
-		"details": "https://docs.polygon.technology/pos/architecture/heimdall/checkpoints/",
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.polygon.technology/",
-	"explorer": [
-		{
-			"url": "https://polygonscan.com/",
-			"description": "Polygonscan"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": false, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"cctp": { "mainnet": true, "testnet": false, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Polygon",
+  "homepage": "https://polygon.technology/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "137"
+  },
+  "testnet": {
+    "name": "Amoy",
+    "id": "80002"
+  },
+  "contractSource": "ethereum/contracts/bridge/Bridge.sol",
+  "finality": {
+    "details": "https://docs.polygon.technology/pos/architecture/heimdall/checkpoints/",
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.polygon.technology/",
+  "explorer": [
+    {
+      "url": "https://polygonscan.com/",
+      "description": "Polygonscan"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/provenance.json
+++ b/scripts/src/chains/provenance.json
@@ -11,5 +11,6 @@
   "mainnet": {
     "name": "Mainnet",
     "id": "pio-mainnet-1"
-  }
+  },
+  "products": {}
 }

--- a/scripts/src/chains/pythnet.json
+++ b/scripts/src/chains/pythnet.json
@@ -12,5 +12,6 @@
       "url": "https://sepolia-optimism.etherscan.io/",
       "description": "OP Sepolia Etherscan"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/scroll.json
+++ b/scripts/src/chains/scroll.json
@@ -1,37 +1,49 @@
 {
-	"title": "Scroll",
-	"homepage": "https://scroll.io/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "534352"
-	},
-	"testnet": {
-		"name": "Sepolia",
-		"id": "534351"
-	},
-	"finality": {
-		"instant": 200,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.scroll.io/en/home/",
-	"faucet": {
-		"url": "https://docs.scroll.io/en/user-guide/faucet/",
-		"token": "ETH",
-		"description": "List of Faucets"
-	},
-	"explorer": [
-		{
-			"url": "https://scrollscan.com/",
-			"description": "Scrollscan"
-		},
-		{
-			"url": "https://sepolia.scrollscan.com/",
-			"description": "Sepolia Scrollscan"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "Scroll",
+  "homepage": "https://scroll.io/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "534352"
+  },
+  "testnet": {
+    "name": "Sepolia",
+    "id": "534351"
+  },
+  "finality": {
+    "instant": 200,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.scroll.io/en/home/",
+  "faucet": {
+    "url": "https://docs.scroll.io/en/user-guide/faucet/",
+    "token": "ETH",
+    "description": "List of Faucets"
+  },
+  "explorer": [
+    {
+      "url": "https://scrollscan.com/",
+      "description": "Scrollscan"
+    },
+    {
+      "url": "https://sepolia.scrollscan.com/",
+      "description": "Sepolia Scrollscan"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/seda.json
+++ b/scripts/src/chains/seda.json
@@ -16,5 +16,6 @@
       "url": "https://explorer.seda.xyz/",
       "description": "SEDA Explorer"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/sei.json
+++ b/scripts/src/chains/sei.json
@@ -1,27 +1,35 @@
 {
-	"title": "Sei",
-	"homepage": "https://www.sei.io/",
-	"devDocs": "https://www.docs.sei.io/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "pacific-1"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "atlantic-2"
-	},
-	"faucet": {
-		"url": "https://atlantic-2.app.sei.io/faucet",
-		"token": "SEI",
-		"description": "Sei Atlantic-2 Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://www.docs.sei.io/dev-ecosystem-providers/explorers#sei-explorers"
-		}
-	],
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Sei",
+  "homepage": "https://www.sei.io/",
+  "devDocs": "https://www.docs.sei.io/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "pacific-1"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "atlantic-2"
+  },
+  "faucet": {
+    "url": "https://atlantic-2.app.sei.io/faucet",
+    "token": "SEI",
+    "description": "Sei Atlantic-2 Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://www.docs.sei.io/dev-ecosystem-providers/explorers#sei-explorers"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/seievm.json
+++ b/scripts/src/chains/seievm.json
@@ -1,6 +1,10 @@
 {
-	"title": "Seievm",
-	"products": {
-		"tokenBridge": { "mainnet": false, "testnet": true, "devnet": false }
-	}
+  "title": "Seievm",
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/sepolia.json
+++ b/scripts/src/chains/sepolia.json
@@ -15,5 +15,17 @@
     "url": "https://www.alchemy.com/faucets/ethereum-sepolia",
     "token": "ETH",
     "description": "Alchemy Faucet"
+  },
+  "products": {
+    "tokenBridge": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    },
+    "cctp": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
+    }
   }
 }

--- a/scripts/src/chains/snaxchain.json
+++ b/scripts/src/chains/snaxchain.json
@@ -1,23 +1,31 @@
 {
-	"title": "SNAXchain",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "2192"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "13001"
-	},
-	"devDocs": "https://docs.synthetix.io/v3/",
-	"homepage": "https://synthetix.io/",
-	"explorer": [
-		{
-			"url": "https://explorer.snaxchain.io/",
-			"description": "SNAXchain Explorer"
-		}
-	],
-	"products": {
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "SNAXchain",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "2192"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "13001"
+  },
+  "devDocs": "https://docs.synthetix.io/v3/",
+  "homepage": "https://synthetix.io/",
+  "explorer": [
+    {
+      "url": "https://explorer.snaxchain.io/",
+      "description": "SNAXchain Explorer"
+    }
+  ],
+  "products": {
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/solana.json
+++ b/scripts/src/chains/solana.json
@@ -1,32 +1,54 @@
 {
-	"title": "Solana",
-	"homepage": "https://solana.com/",
-	"mainnet": {
-		"name": "Mainnet Beta",
-		"id": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"
-	},
-	"testnet": {
-		"name": "Devnet",
-		"id": "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"
-	},
-	"notes": ["The contract addresess for testnet are on the Solana devnet"],
-	"explorer": [
-		{
-			"url": "https://explorer.solana.com/",
-			"description": "Solana Explorer"
-		}
-	],
-	"finality": {
-		"details": "https://docs.anza.xyz/consensus/commitments/",
-		"confirmed": 0,
-		"finalized": 1
-	},
-	"devDocs": "https://solana.com/docs",
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": true },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true },
-		"settlement": { "mainnet": true, "testnet": true, "devnet": false },
-		"multigov": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Solana",
+  "homepage": "https://solana.com/",
+  "mainnet": {
+    "name": "Mainnet Beta",
+    "id": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"
+  },
+  "testnet": {
+    "name": "Devnet",
+    "id": "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"
+  },
+  "notes": [
+    "The contract addresess for testnet are on the Solana devnet"
+  ],
+  "explorer": [
+    {
+      "url": "https://explorer.solana.com/",
+      "description": "Solana Explorer"
+    }
+  ],
+  "finality": {
+    "details": "https://docs.anza.xyz/consensus/commitments/",
+    "confirmed": 0,
+    "finalized": 1
+  },
+  "devDocs": "https://solana.com/docs",
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/stargaze.json
+++ b/scripts/src/chains/stargaze.json
@@ -10,5 +10,6 @@
     {
       "url": "https://www.mintscan.io/stargaze"
     }
-  ]
+  ],
+  "products": {}
 }

--- a/scripts/src/chains/sui.json
+++ b/scripts/src/chains/sui.json
@@ -1,34 +1,46 @@
 {
-	"title": "Sui",
-	"homepage": "https://sui.io/",
-	"explorer": [
-		{
-			"url": "https://suiscan.xyz/",
-			"description": "Suiscan"
-		}
-	],
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "35834a8a"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "4c78adac"
-	},
-	"finality": {
-		"details": "https://docs.sui.io/concepts/sui-architecture/consensus",
-		"finalized": 0,
-		"otherwise": ""
-	},
-	"devDocs": "https://docs.sui.io/",
-	"faucet": {
-		"url": "https://docs.sui.io/build/faucet",
-		"token": "SUI",
-		"description": "List of Faucets"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false }
-	}
+  "title": "Sui",
+  "homepage": "https://sui.io/",
+  "explorer": [
+    {
+      "url": "https://suiscan.xyz/",
+      "description": "Suiscan"
+    }
+  ],
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "35834a8a"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "4c78adac"
+  },
+  "finality": {
+    "details": "https://docs.sui.io/concepts/sui-architecture/consensus",
+    "finalized": 0,
+    "otherwise": ""
+  },
+  "devDocs": "https://docs.sui.io/",
+  "faucet": {
+    "url": "https://docs.sui.io/build/faucet",
+    "token": "SUI",
+    "description": "List of Faucets"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/terra.json
+++ b/scripts/src/chains/terra.json
@@ -1,27 +1,35 @@
 {
-	"title": "Terra",
-	"homepage": "https://www.terra.money/",
-	"devDocs": "https://classic-docs.terra.money/docs/full-node/run-a-full-terra-node/join-a-network.html",
-	"faucet": {
-		"url": "https://faucet.terra.money/",
-		"token": "LUNA",
-		"description": "Terra Official Faucet"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "columbus-5"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "bombay-12"
-	},
-	"explorer": [
-		{
-			"url": "https://classic-docs.terra.money/docs/ecosystem/explore.html?highlight=explorer#block-explorers"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": false, "testnet": false, "devnet": true },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Terra",
+  "homepage": "https://www.terra.money/",
+  "devDocs": "https://classic-docs.terra.money/docs/full-node/run-a-full-terra-node/join-a-network.html",
+  "faucet": {
+    "url": "https://faucet.terra.money/",
+    "token": "LUNA",
+    "description": "Terra Official Faucet"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "columbus-5"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "bombay-12"
+  },
+  "explorer": [
+    {
+      "url": "https://classic-docs.terra.money/docs/ecosystem/explore.html?highlight=explorer#block-explorers"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": false,
+      "testnet": false,
+      "devnet": true
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/terra2.json
+++ b/scripts/src/chains/terra2.json
@@ -1,27 +1,31 @@
 {
-	"title": "Terra 2.0",
-	"homepage": "https://www.terra.money/",
-	"devDocs": "https://docs.terra.money/",
-	"faucet": {
-		"url": "https://faucet.terra.money/",
-		"token": "LUNA",
-		"description": "Terra Official Faucet"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "phoenix-1"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "pisco-1"
-	},
-	"explorer": [
-		{
-			"url": "https://finder.terra.money/",
-			"description": "Terra Finder"
-		}
-	],
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": true }
-	}
+  "title": "Terra 2.0",
+  "homepage": "https://www.terra.money/",
+  "devDocs": "https://docs.terra.money/",
+  "faucet": {
+    "url": "https://faucet.terra.money/",
+    "token": "LUNA",
+    "description": "Terra Official Faucet"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "phoenix-1"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "pisco-1"
+  },
+  "explorer": [
+    {
+      "url": "https://finder.terra.money/",
+      "description": "Terra Finder"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
 }

--- a/scripts/src/chains/unichain.json
+++ b/scripts/src/chains/unichain.json
@@ -1,35 +1,51 @@
 {
-	"title": "Unichain",
-	"homepage": "https://www.unichain.org/",
-	"mainnet": {
-		"name": "",
-		"id": ""
-	},
-	"testnet": {
-		"name": "Unichain Sepolia",
-		"id": "1301"
-	},
-	"explorer": [
-		{
-			"url": "https://sepolia.uniscan.xyz/",
-			"description": "Unichain Sepolia Testnet Explorer"
-		}
-	],
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"devDocs": "https://docs.unichain.org/docs",
-	"faucet": {
-		"url": "https://faucet.quicknode.com/unichain/sepolia",
-		"token": "ETH",
-		"description": "QuickNode Faucet"
-	},
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false },
-		"settlement": { "mainnet": true, "testnet": false, "devnet": false }
-	}
+  "title": "Unichain",
+  "homepage": "https://www.unichain.org/",
+  "mainnet": {
+    "name": "",
+    "id": ""
+  },
+  "testnet": {
+    "name": "Unichain Sepolia",
+    "id": "1301"
+  },
+  "explorer": [
+    {
+      "url": "https://sepolia.uniscan.xyz/",
+      "description": "Unichain Sepolia Testnet Explorer"
+    }
+  ],
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "devDocs": "https://docs.unichain.org/docs",
+  "faucet": {
+    "url": "https://faucet.quicknode.com/unichain/sepolia",
+    "token": "ETH",
+    "description": "QuickNode Faucet"
+  },
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "settlement": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/xlayer.json
+++ b/scripts/src/chains/xlayer.json
@@ -1,34 +1,46 @@
 {
-	"title": "X Layer",
-	"homepage": "https://www.okx.com/xlayer",
-	"devDocs": "https://www.okx.com/xlayer/docs/developer/build-on-xlayer/about-xlayer",
-	"testnet": {
-		"name": "Testnet",
-		"id": "195"
-	},
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "196"
-	},
-	"finality": {
-		"instant": 200,
-		"safe": 201,
-		"otherwise": "finalized"
-	},
-	"faucet": {
-		"url": "https://www.okx.com/xlayer/faucet",
-		"token": "OKB",
-		"description": "X Layer Official Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://zksync.l2scan.co/",
-			"description": "L2Scan"
-		}
-	],
-	"products": {
-		"connect": { "mainnet": true, "testnet": true, "devnet": false },
-		"ntt": { "mainnet": true, "testnet": true, "devnet": false },
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "X Layer",
+  "homepage": "https://www.okx.com/xlayer",
+  "devDocs": "https://www.okx.com/xlayer/docs/developer/build-on-xlayer/about-xlayer",
+  "testnet": {
+    "name": "Testnet",
+    "id": "195"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "196"
+  },
+  "finality": {
+    "instant": 200,
+    "safe": 201,
+    "otherwise": "finalized"
+  },
+  "faucet": {
+    "url": "https://www.okx.com/xlayer/faucet",
+    "token": "OKB",
+    "description": "X Layer Official Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://zksync.l2scan.co/",
+      "description": "L2Scan"
+    }
+  ],
+  "products": {
+    "connect": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }

--- a/scripts/src/chains/xpla.json
+++ b/scripts/src/chains/xpla.json
@@ -1,27 +1,31 @@
 {
-	"title": "XPLA",
-	"homepage": "https://www.xpla.io/en",
-	"devDocs": "https://docs.xpla.io/develop/develop/get-started/",
-	"mainnet": {
-		"name": "Mainnet",
-		"id": "dimension_37-1"
-	},
-	"testnet": {
-		"name": "Testnet",
-		"id": "cube_47-5"
-	},
-	"faucet": {
-		"url": "https://faucet.xpla.io/",
-		"token": "XPLA",
-		"description": "XPLA Official Faucet"
-	},
-	"explorer": [
-		{
-			"url": "https://explorer.xpla.io/",
-			"description": "XPLA Explorer"
-		}
-	],
-	"products": {
-		"tokenBridge": { "mainnet": true, "testnet": true, "devnet": false }
-	}
+  "title": "XPLA",
+  "homepage": "https://www.xpla.io/en",
+  "devDocs": "https://docs.xpla.io/develop/develop/get-started/",
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "dimension_37-1"
+  },
+  "testnet": {
+    "name": "Testnet",
+    "id": "cube_47-5"
+  },
+  "faucet": {
+    "url": "https://faucet.xpla.io/",
+    "token": "XPLA",
+    "description": "XPLA Official Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://explorer.xpla.io/",
+      "description": "XPLA Explorer"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    }
+  }
 }


### PR DESCRIPTION
### **Description:**
This PR introduces automation to detect and populate `tokenBridge` and `cctp` support in individual chain files based on deployed contracts in the Wormhole SDK. When running npm run generate, the script will now:
- Check for deployed Token Bridge and CCTP contracts across all environments (mainnet, testnet, devnet)
- Automatically update the corresponding products field in each chain’s JSON file, if applicable
- Preserve existing file content (e.g. names, faucets, explorer links) without overwriting unrelated data

This eliminates the need to manually maintain tokenBridge and cctp support in the chain metadata files and reduces human error.

Please review and merge this PR only after PR #233 is merged.