### PR TITLE
fix the footer llms button

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -317,8 +317,7 @@
             ? fileName 
             : `llms-files/${fileName}`;
 
-          // const url = `https://wormhole.com/docs/${filePath}`;
-          const url = `https://papermoonio.github.io/wormhole-mkdocs/${filePath}`;
+          const url = `https://wormhole.com/docs/${filePath}`;
 
           if (action === 'copy') {
             copyTxtFile(url, fileName);

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -62,7 +62,7 @@
         <div class="llms">
           <div>
             <span class="footer-title">AI Resources</span>
-            <button class="md-clipboard--inline md-icon llms copy md-button" title="{{ lang.t('clipboard.copy') }}" value="llms-full.txt" action="copy">
+            <button class="md-clipboard--inline md-icon llms copy md-button" title="{{ lang.t('clipboard.copy') }}" data-value="llms-full.txt" action="copy">
               {% include ".icons/material/content-copy.svg" %} llms-full.txt
             </button>
           </div>


### PR DESCRIPTION
The footer llms button didn't have the correct property set. The script was looking for the `data-value` attribute, but `value` was being used instead. Also the wrong url was set (probably leftover from testing).