### PR TITLE
Add HyperEVM warning to title

### DIFF
--- a/scripts/src/chains/HyperEVM.json
+++ b/scripts/src/chains/HyperEVM.json
@@ -1,5 +1,5 @@
 {
-  "title": "HyperEVM",
+  "title": "HyperEVM :material-information-outline:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }",
   "testnet": {
     "name": "Testnet",
     "id": "998"


### PR DESCRIPTION
This PR adds a hack to include the warning in the HyperEVM title. Probably a better way to do this, but it works for now 🤷‍♀️ 