### PR TITLE
Martinh/fix 404s

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -6,5 +6,5 @@ localhost
 https://fonts.gstatic.com/**
 https://fonts.googleapis.com/**
 
-# Ignore links that are working
+# Allowlist known working URLs
 https://atlantic-2.app.sei.io/faucet

--- a/.urlignore
+++ b/.urlignore
@@ -1,0 +1,10 @@
+# Ignore localhost
+localhost
+127.0.0.1
+
+# Ignore Google Fonts service and all its assets
+https://fonts.gstatic.com/**
+https://fonts.googleapis.com/**
+
+# Ignore links that are working
+https://atlantic-2.app.sei.io/faucet

--- a/scripts/src/chains/avalanche.json
+++ b/scripts/src/chains/avalanche.json
@@ -24,7 +24,7 @@
     "otherwise": "finalized",
     "details": "https://build.avax.network/docs/dapps/advanced-tutorials/exchange-integration#determining-finality"
   },
-  "devDocs": "https://build.avax.network/docs",
+  "devDocs": "https://build.avax.network/docs/",
   "faucet": {
     "url": "https://core.app/tools/testnet-faucet/?subnet=c&token=c",
     "token": "AVAX",

--- a/scripts/src/chains/avalanche.json
+++ b/scripts/src/chains/avalanche.json
@@ -22,9 +22,9 @@
   "finality": {
     "instant": 200,
     "otherwise": "finalized",
-    "details": "https://docs.avax.network/dapps/advanced-tutorials/exchange-integration#determining-finality"
+    "details": "https://build.avax.network/docs/dapps/advanced-tutorials/exchange-integration#determining-finality"
   },
-  "devDocs": "https://docs.avax.network/",
+  "devDocs": "https://build.avax.network/docs",
   "faucet": {
     "url": "https://core.app/tools/testnet-faucet/?subnet=c&token=c",
     "token": "AVAX",

--- a/scripts/src/chains/base.json
+++ b/scripts/src/chains/base.json
@@ -11,10 +11,6 @@
   },
   "explorer": [
     {
-      "url": "https://goerli.basescan.org/",
-      "description": "Etherscan"
-    },
-    {
       "url": "https://base-goerli.blockscout.com/",
       "description": "Blockscout"
     }

--- a/scripts/src/chains/mantle.json
+++ b/scripts/src/chains/mantle.json
@@ -14,7 +14,7 @@
     "safe": 201,
     "otherwise": "finalized"
   },
-  "devDocs": "https://docs.mantle.xyz/network/introduction/overview",
+  "devDocs": "https://docs.mantle.xyz/network/",
   "faucet": {
     "url": "https://faucet.sepolia.mantle.xyz/",
     "token": "MNT",

--- a/scripts/src/chains/snaxchain.json
+++ b/scripts/src/chains/snaxchain.json
@@ -8,7 +8,7 @@
     "name": "Testnet",
     "id": "13001"
   },
-  "devDocs": "https://docs.synthetix.io/v3/",
+  "devDocs": "https://docs.synthetix.io/",
   "homepage": "https://synthetix.io/",
   "explorer": [
     {


### PR DESCRIPTION
This pull request introduces updates to URL configurations and documentation links across multiple files. The changes include adding URL ignore rules, updating outdated documentation links, and removing redundant explorer entries.

### URL Configuration Updates:

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R1-R10): Added rules to ignore localhost, Google Fonts assets, and specific working links to streamline URL handling.

### Documentation Link Updates:

* [`scripts/src/chains/avalanche.json`](diffhunk://#diff-7dc9cf9bcd58202f465b5baaec6823e6bfb63ac2ad2bca8319261e5194323a77L25-R27): Updated `details` and `devDocs` URLs to point to the new `build.avax.network` domain.
* [`scripts/src/chains/mantle.json`](diffhunk://#diff-2ff45b75dbfc0214451b109576a46011b47c23e9ea51eddd8ecc47a0c18d237aL17-R17): Updated the `devDocs` URL to a more general path on the Mantle documentation site.
* [`scripts/src/chains/snaxchain.json`](diffhunk://#diff-e410db900f4e351afcee7e2053d3f67f512efee358eb7a9439946b02f73f6c80L11-R11): Updated the `devDocs` URL to remove the version-specific path, pointing to the main Synthetix documentation.

### Explorer Entry Simplification:

* [`scripts/src/chains/base.json`](diffhunk://#diff-a938d74c2eef50f8f0de1de0405c28aeaf421af3adfc22d1dc2c02ba579f8c4fL13-L16): Removed the `Etherscan` explorer entry for the Base Goerli testnet, leaving only the `Blockscout` entry.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/489