### PR TITLE
Update sdk to v.3.0.3

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.0.2",
+        "@wormhole-foundation/sdk": "3.0.3",
         "sharp": "^0.34.3",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
-        "@types/node": "^24.0.14",
+        "@types/node": "^24.0.15",
         "markdown-link-check": "^3.13.7",
         "typescript": "^5.8.3"
       }
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
-      "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.0.tgz",
+      "integrity": "sha512-Jj74qfIplT+MzUUWABeUJxHF5lxiyOJpE4ENeIOwvcPAi+QYoxsKNj/aPcGAk2jK5CrP9aFtE5O7794q2rWjlQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
+      "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -2005,9 +2005,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -2057,52 +2057,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.0.2.tgz",
-      "integrity": "sha512-PNZ26LLP2Ds+XijPBO8HRvRZlrQ3nlA3aL2OAQkyi+uRkOiU17iiDU5qjbIIz+1dlCotkkfrMLOX+d2zTV9mWw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.0.3.tgz",
+      "integrity": "sha512-OSlB5ZGPnb1odwFEzFL7oVsYM3scqg97UGLf5+52vOng6vK42J7tFUasXOKMYVY/HfwA6teqWGF/bVpJmepWvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.2",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.2",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.0.2",
-        "@wormhole-foundation/sdk-aptos": "3.0.2",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.0.2",
-        "@wormhole-foundation/sdk-aptos-core": "3.0.2",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.0.2",
-        "@wormhole-foundation/sdk-base": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.0.2",
-        "@wormhole-foundation/sdk-definitions": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
-        "@wormhole-foundation/sdk-evm-cctp": "3.0.2",
-        "@wormhole-foundation/sdk-evm-core": "3.0.2",
-        "@wormhole-foundation/sdk-evm-portico": "3.0.2",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.0.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.2",
-        "@wormhole-foundation/sdk-solana": "3.0.2",
-        "@wormhole-foundation/sdk-solana-cctp": "3.0.2",
-        "@wormhole-foundation/sdk-solana-core": "3.0.2",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.0.2",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.2",
-        "@wormhole-foundation/sdk-sui": "3.0.2",
-        "@wormhole-foundation/sdk-sui-cctp": "3.0.2",
-        "@wormhole-foundation/sdk-sui-core": "3.0.2",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.0.2"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-core": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-core": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-base": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-definitions": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
+        "@wormhole-foundation/sdk-evm-portico": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3",
+        "@wormhole-foundation/sdk-sui-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-sui-core": "3.0.3",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.0.2.tgz",
-      "integrity": "sha512-zlay130LkrsbZwhiU5erUbYGsjmG1WCG7fgqvU8mrHXMPIpVBc4Ki8JboUqzAAixFbexfMHMOw1AF6vIpbO0Jw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.0.3.tgz",
+      "integrity": "sha512-tCjKvGgwW/aFkQ5gETKMjbcKtQ6uC2eVtL3DxVO+c67WFn7AayBfljr+kXAksaKVdc8hFwSWZAk5FkpAVI1CvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2110,89 +2110,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.0.2.tgz",
-      "integrity": "sha512-yHbLJfUp8GJSYlE8/UP2nUaL9d8mqC/FkLX1i8wJfNVDuIzmie5kYyty1NYSq3kEsDdJlIJ9OmcilN3s9iW/ww==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.0.3.tgz",
+      "integrity": "sha512-j/7SJfkr5KTWE1Nr9y46Ef3bALPU8fHDh7UwnRv4Jo76n5HBqf2HibThwmjKS1+kCBk4OGnS6W5QULLKb3Psgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-nAhRcocI/vGAJv3yEv6DiTZoElWMZl5pILd4UkiZhf7Y2XnvH62/+Bhu1NzN02Y+0Z3zPGhqjSG0iq2xXJcYUw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-kQi3eyPqnK+HQS8shWiahx6DyTvUtohq+lOiGd/Cy+Altq+P4wHPnA9j/LgxGmqi/6CPP/YyTqkLXp7iIW2w/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.2",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-core": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.0.2.tgz",
-      "integrity": "sha512-ykEgxMZvCFCdHb/baXKaT+zcCy2g7doNkjrbAuEpo3OClzTTFXF6BeiXGWdGP/9GZyeVE+75pYVFZq5mx8HQaQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.0.3.tgz",
+      "integrity": "sha512-2f1w3O6b3cufZKVa0R+zSLehejb3b4D+7q1m2Wgp2134pbxSOIGMwqBXeA4/8yNnLNnZPGUfoOt5hKKi/aEVZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.0.2.tgz",
-      "integrity": "sha512-oTCTT/meDJ5uk1CoGA0+GKqFOLVY1s+oLMf/uIACo1ZKho1xEaxT5hmr30bX5XhUtp/46Kz6b7aIU6XCidQFBQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.0.3.tgz",
+      "integrity": "sha512-noOD9pEe2hKEWydAPjfbYrrrN2Z9b5cHwP5Kaq/sx/TIbCFsYhXrCZZ4thzHKrJnaDUVdA/NLSsWAwBRif8ifw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.0.2.tgz",
-      "integrity": "sha512-dmx+zzeo0GoFTM4c0vtcLY0aPCPrm8itQCaEvYFuZzuJETzjFqYWuaGJogCktI03sbjqK7u9IH+/t6wI+kwpDw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.0.3.tgz",
+      "integrity": "sha512-ISh5+ACSw9x83BaJO/O68Y1G/DnfryCrTzQde2saJLlMJWt07Jj/WSq478cVwvDgjN0hRg04vMieVW0+2SGWdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-LMpYKMmfzCwI96xstPDr+fApebjgLSAcz5/lVgOf+RvFJdTTDyi4LmGekMOm0UoWDG1RQe/dQrx7/WRhc5NgnA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-KYhBwMMoe6QW0TSJEhzy8hM7shLqeeNbar17pRrzUtDzBZ++CJxaA5363tRxb1GgOG+NVkv2p+78yqlGSCPa3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.0.2.tgz",
-      "integrity": "sha512-JlQyb6preGbDdiskIGtGJA7uvQRdqh6bCWlQaH+otddSWrbgLLlgWgo+eQW1tZOV2m5nUmePXaAQIR96mqDEMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.0.3.tgz",
+      "integrity": "sha512-Q+1Wgle6nQeO5AhaPYaTkcX+Jj1FzBm1XyqYeUfbv7ERbZrmpPa5XdtXBSbw8tNMv6u375BRO+hZkbI6JPKqNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2200,13 +2200,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.0.2.tgz",
-      "integrity": "sha512-8MTp8f7xlPZx96KMygk7mOzM5Ldv5Vex5q7ARwTflJBPrvQghE/kPRL+HwyOliWh/jy69A24OrIZ6inmeH2Xhg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.0.3.tgz",
+      "integrity": "sha512-/UJ3+TaCHaT2cydkrM0mZX/OJIN86RGQeNmEphvuqwdrUKjv4RCii6mQf7eHHKzOLrXoHjGfiq5GmDUAcDrIDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.0.2",
-        "@wormhole-foundation/sdk-definitions": "3.0.2",
+        "@wormhole-foundation/sdk-base": "3.0.3",
+        "@wormhole-foundation/sdk-definitions": "3.0.3",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2214,16 +2214,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.0.2.tgz",
-      "integrity": "sha512-6Qh4gkQTF8w2gEhCGokxJTBg7n10KbIXWBv0+lsqaHsSfDWa3pgmCDzbCzkscJ+vU4OBT6sv7+mATXUVpcsPEg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.0.3.tgz",
+      "integrity": "sha512-SzZpagvIl5UjsLrEAI4uW5EeAlLllRTJyq4GEALDhQKgB6NhXLlVThWYvrGA0WrFxt9Lbv9Jg6Pbc1NDnVSfSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2231,33 +2231,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.0.2.tgz",
-      "integrity": "sha512-5LcFtnon//TTx9awE6YoHALMtJlJEXyNdH/qHZDAgvOg7UjfKfz/uVVediPRrUIXhe9ORUnI/yWbV20jtUpKrg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.0.3.tgz",
+      "integrity": "sha512-JK7rC1poKHelWP9BiYqEP45cwlXSSZSAqO6imUjQL5gNKg5zb43sCmJX02W3pX8tzcDM0v3cIlb6BGnL3Qf/DA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.0.2.tgz",
-      "integrity": "sha512-AQ1N4QySuFW+BLQP6uTvT3Y10aS/U+dcwf5qiyno5uCD0BigU4i7Q9XXhRsAS+C6hAv/7Xw9ub8Wg3rIGvj/8Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.0.3.tgz",
+      "integrity": "sha512-6JDw+/td9AQKrKDp5MdDFiny5xkvCAcq4LS/GeFZdchA3Id3p7XDXkJaaGPxApDe4iij6UdFFo7coayPJixUBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.3",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2265,37 +2265,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-LiAeoClJIa15y9+dr7Aw4xEwENmA/TuU9PF2bPRXQoe0xP8nPTsaVeKENL65ixY+BKfIqP/GgSw3bKbqzJUbCA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-IqXb3Yw5q7JwJbwa9BE7z5k2HGLLgtHt1K7T3pCCbyo5cu9MdrPV4PGdhPRp4PQTyRW4+A93kUYhEccI799Uig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.0.2.tgz",
-      "integrity": "sha512-WrBIUwG+BPdC7tVpetFLw4b48QdaujPNboqqiwuCWCisK1YHs1GiFM1fK5ZtYQ/M+3ImhBAX7g+hkHz47qXiuw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.0.3.tgz",
+      "integrity": "sha512-mwbr4il7ZK4zInAWtSQg+5/BJOZ+FcmeOw49N4EAAFCgIHLQ4KqWBt/9SThp5B/rsbFjmfGR6515m8rCuZE37g==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.0.2"
+        "@wormhole-foundation/sdk-base": "3.0.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.0.2.tgz",
-      "integrity": "sha512-VR9datVjz2X+NLDCmycWaHNv9e3XzfYXda9e0tgRQLPLUGzTH3uQcwEzZHTygJVEN5lWOOTcrQkvqAUza3ofcQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.0.3.tgz",
+      "integrity": "sha512-7598LdmIy/fbMzBEQORZfb1nviI3mL8S20w8JJLcnuE9PrzFJ0q8uNHzW5DmT0SdLvvBAWQEQHvunOY251b3AQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2303,14 +2303,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.0.2.tgz",
-      "integrity": "sha512-aNyH7bW4togzRMHLDnWwRZ16LAaxGlZ/RcTO+WapKhci0uYbMt5KaejPQxSbpdTA1aqH8caled0pSHvxWXuJzg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.0.3.tgz",
+      "integrity": "sha512-dkmAd4xrJuIliHiUUGCpqyQMd7XyQ7Mu7Qq+S+4N40pIk8qe7hSvzqktI+Pz0Da5Vxo/+gd1+L+dKmZTZggZqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
-        "@wormhole-foundation/sdk-evm-core": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2318,13 +2318,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.0.2.tgz",
-      "integrity": "sha512-znjKj02l/nFfe3U7IpCcsiHdOk0F8Rw2/fDY1swDQTx8r6fNHF8q1nYC4JZpHW3n0o5V1TO+msrnQfk1ZiUnhw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.0.3.tgz",
+      "integrity": "sha512-w9IZ/OSuHUlZhddcOvZbGtpbdenLi17AL31fimdgJwybYqcjO1iS1SVPeuDk58lgcIAYlFW79YGNasFE6+lIjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2332,15 +2332,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.0.2.tgz",
-      "integrity": "sha512-n7Z1MUONuYygdyV6xY+AX4vXnfxA+AMlkJNBu+WWSLnlOab57Geuaj7tK4N9lZ3vgz7iy9LZD8xYqBNAyP1NQw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.0.3.tgz",
+      "integrity": "sha512-5SDbsTFSVK5cU4qelYOm/KZA/VeGDYhnSXS+jGTbc527x1rR4eYpZhJsZyUBHMh7hEpYPpbKO8Jp9yeLLLGwWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
-        "@wormhole-foundation/sdk-evm-core": "3.0.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2348,14 +2348,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.0.2.tgz",
-      "integrity": "sha512-yfytxsZvvYLR0E2/vUsPrw6aM7067ubkszEMkspJDpkbckxRw6dvMXxwfqYQX9kWsOmICfU5j4HIVUo9iSdHuw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.0.3.tgz",
+      "integrity": "sha512-Z8VI9MPeyizCxE8yRQ3HfUUgYPNcB5fG3bmmiGdWUWwQ+JG5gnqeUKK2bCK+iQVKKKm0nNsTeBFF6uVYWD4SQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
-        "@wormhole-foundation/sdk-evm-core": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2363,14 +2363,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-wSnZniZ5AWax9YiuXNpiTm3gD3+spkuDj7K+x6m6PUcRIorrDrzjVTmi+ho7KJs907mV2neoSL0dBeyq4369JQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-2KH9rQR4InGYa+qMBW5r+4xno4mOVR6qkoSTe8WjDiAtiryX8sKddoZ4l6iCP/Orp6R9Bzu4JfcObZz0AWcDnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-evm": "3.0.2",
-        "@wormhole-foundation/sdk-evm-core": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2378,16 +2378,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.0.2.tgz",
-      "integrity": "sha512-wh4o0MfXO6XpoMrAKRAws6losio2EeTtJo/w4GEgkNOZLPSztFf4+/d9YJecsd6WZRvfBwrOYH+TiFr/ogs8lg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.0.3.tgz",
+      "integrity": "sha512-YBwYC1zFhWWG/997gx4s8i92a9tDRKt8ITNlPoVoy+1aI+aJzLB+TumDCrU1NCEIAKLXoqKZ+206XluD/hDF3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2395,123 +2395,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.0.2.tgz",
-      "integrity": "sha512-pajT4+19/xg02weeHQqRMN7Z9aPmTMizHyTdTxFPTQfvSP3jKF7o250H1S6hRoCtIeEiWEmDtd56Glns8QIsCg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.0.3.tgz",
+      "integrity": "sha512-MjZgo1pN5Bg4rTvg7+MeUoNaDAm8lg8WuahvJogmFe1voKC8kniRzHghm9x9S8zoUuH/HyUiBhIurgNjDe0Z2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-solana": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.0.2.tgz",
-      "integrity": "sha512-UGluyL1GROnCcmJF/exApGzTB2NJ0Z19w/tkaKUP9ZxpJG07PnO5PjQ3Z3OVGO2lXcGP08SzG9mD3kHk4xHHQw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.0.3.tgz",
+      "integrity": "sha512-vP/POBI7aG+w6iUDCgDZlhm9S25c6Bszw7E2VVrgAR/lM/YnGO5AzM6nWRLt6k7MYH6AoSu88LqjYUYY45wGng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-solana": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.0.2.tgz",
-      "integrity": "sha512-hIPN9yivJ7opITMR6f3e0R2yLMCPWZB8H8a9azGjdT0Yd5jzfpLsM85A5abUiAVAojvG53YVqbwueKFKItP4Lw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.0.3.tgz",
+      "integrity": "sha512-2q8olQjuYruYoMeZwGX00KuyVdW96TxuunZzhqeN2AXhUmyQVHFhO51/lfIHvH9sf2xuIuZGHC+Kk9YQKBZjlw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-solana": "3.0.2",
-        "@wormhole-foundation/sdk-solana-core": "3.0.2",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-rh22XrKijTCZDD66p3qi3093xLbmUM+xscvG4ly14YiMw1MlhkmyPkz3M2jZJQeHwZeCQJcflAP1R4wwa88fOg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-GhgChS59wyvtdnHtDFJAW5wp5POfXczLP2hBfM5zgRC/GI/Jo2AXm+Yhz7vhQTBdXvCsEY74Io8gQBjX/QlUlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-solana": "3.0.2",
-        "@wormhole-foundation/sdk-solana-core": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.0.2.tgz",
-      "integrity": "sha512-8mx4Eucsl5MLSktJ40tkWCp7IHx2HCYoicRpP81bakPizBKdwRrwU23OKcplCbFDuHr0fsusKpxSaMnYKMjg0g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.0.3.tgz",
+      "integrity": "sha512-MTq3Sav0OOIz+CePdGsg12w5hQlKqBZ1qnK8BkiGOYJzsay3qdROM4l7IFQrJXq7xCVr2t+Yexrj2/5QA8Osew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.0.2.tgz",
-      "integrity": "sha512-UIuNT9K90gjfktvUhZORejzSRm0cLLHfz1+Mq24pw3paWZs6ahPleYXr3hroObRVCBWJXaDV/zGhXEGDCsHP4w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.0.3.tgz",
+      "integrity": "sha512-ixNtj/x/rgNomLpMhof8kdfO5WC4f+3hXvY4gQnXwargFeVV0Tc4V8OZ6SnL+8vB1LurhnjpnPXdxAAHCYs47Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-sui": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.0.2.tgz",
-      "integrity": "sha512-HRHW3inAOJvy7Z1GX0wh05+rw5BEn+MdQSmj42RhD0ZpGmlqtjxjzkBKkDfNcNzlijKlka4UOoJVZS/kNahExQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.0.3.tgz",
+      "integrity": "sha512-uQp8LE6BtRAOkhfNdQP18WF9iF9Suyn0S122Mn4V2yUmT0Jodlah2ZsWRi6YcHsvkzPzhVnZ65I0x0UzO0CmUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-sui": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.0.2.tgz",
-      "integrity": "sha512-kaoL5YDE3uHHosc/dH92V434xI2vy8HOZ2o7Xww0RPpo129SBc+EEK4wYLew9dJPgeHhCZpYaU46MhFZxiboQg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-O4dZHLxjLH1Tufhz9DOVmnXhj1fPFE8grJCGxquza64NRHAJ3kvrT9Z/AoneQ8Fdxkp1arqtWNxGTJtb547D6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.2",
-        "@wormhole-foundation/sdk-sui": "3.0.2",
-        "@wormhole-foundation/sdk-sui-core": "3.0.2"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3",
+        "@wormhole-foundation/sdk-sui-core": "3.0.3"
       },
       "engines": {
         "node": ">=16"
@@ -3970,9 +3970,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4150,14 +4150,14 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.11.tgz",
-      "integrity": "sha512-b94SV2ki1yZWm/MGzWIaWxuPJUMAYjlQllwoD9b8/GCVXKax1HS9xPfLq/p47UmAnUY3X8qDF0JdMEIr0EKmOA==",
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.12.tgz",
+      "integrity": "sha512-VuHbhYyhPN7XDc06Gl3jYWxMlqa1MLX5xbrmbBbzelX/+M5khxDsNBE7FvTEvAmx0RyLyDkEtRPWRfIdMCTKTw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.6.3",
+        "@gql.tada/cli-utils": "1.7.0",
         "@gql.tada/internal": "1.0.8"
       },
       "bin": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.0.15",
     "markdown-link-check": "^3.13.7",
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.0.2",
+    "@wormhole-foundation/sdk": "3.0.3",
     "sharp": "^0.34.3",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/chains/seievm.json
+++ b/scripts/src/chains/seievm.json
@@ -1,5 +1,17 @@
 {
   "title": "Seievm",
+  "homepage": "https://www.sei.io/",
+  "devDocs": "https://docs.sei.io/evm",
+  "faucet": {
+    "url": "https://atlantic-2.app.sei.io/faucet",
+    "token": "SEI",
+    "description": "Sei Atlantic-2 Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://seistream.app/"
+    }
+  ],
   "products": {
     "tokenBridge": {
       "mainnet": true,
@@ -15,6 +27,11 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
     }
   }
 }

--- a/scripts/src/generated/cctp-support.json
+++ b/scripts/src/generated/cctp-support.json
@@ -12,7 +12,8 @@
     "Unichain",
     "Sonic",
     "Linea",
-    "Worldchain"
+    "Worldchain",
+    "Seievm"
   ],
   "Testnet": [
     "Sepolia",
@@ -27,6 +28,7 @@
     "Unichain",
     "Sonic",
     "Linea",
+    "Seievm",
     "Ethereum",
     "Optimism",
     "Arbitrum",


### PR DESCRIPTION
This pull request updates several dependencies in the `scripts/package-lock.json` file to their latest versions, ensuring compatibility and access to the latest features and fixes. The updates include both production and development dependencies.

### Dependency Updates:

#### Production Dependencies:
* Updated `@wormhole-foundation/sdk` from version `3.0.2` to `3.0.3`, likely including minor fixes or improvements.

#### Development Dependencies:
* Updated `@types/node` from version `24.0.14` to `24.0.15`, ensuring type definitions for Node.js remain up to date. [[1]](diffhunk://#diff-eb9df6c0a86f6d8ca5ed2f00a5abe652fc4d7f254056b7e9855d05a746b6699bL12-R17) [[2]](diffhunk://#diff-eb9df6c0a86f6d8ca5ed2f00a5abe652fc4d7f254056b7e9855d05a746b6699bL2008-R2010)

#### Other Dependency Updates:
* Updated `@gql.tada/cli-utils` from version `1.6.3` to `1.7.0`, which may include new features or bug fixes.
* Updated `@noble/curves` from version `1.9.2` to `1.9.4`, likely addressing performance improvements or bug fixes.