### PR TITLE
Add new website to urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -13,3 +13,6 @@ https://atlantic-2.app.sei.io/faucet
 https://x.com/
 https://twitter.com/
 https://instagram.com/
+
+# Ignore sites that work
+https://metamask.io/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include an additional URL to be ignored.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R16-R18): Added `https://metamask.io/` to the list of ignored URLs, with a comment explaining that it is a site that works.

Related to this issue: https://github.com/wormhole-foundation/wormhole-docs/issues/541