### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -8,6 +8,7 @@ https://fonts.googleapis.com/**
 
 # Allowlist known working URLs
 https://atlantic-2.app.sei.io/faucet
+https://metamask.io/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include a new URL in the allowlist.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R11): Added `https://metamask.io/` to the allowlist of known working URLs.