### PR TITLE
Martinh/update submodule to 7ab3fc2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "wormhole-docs"]
 	path = wormhole-docs
 	url = https://github.com/wormhole-foundation/wormhole-docs
+	branch = dev

--- a/.urlignore
+++ b/.urlignore
@@ -13,3 +13,6 @@ https://atlantic-2.app.sei.io/faucet
 https://x.com/
 https://twitter.com/
 https://instagram.com/
+
+# Ignore sites that work
+https://metamask.io/


### PR DESCRIPTION
This pull request updates the Git submodule configuration for `wormhole-docs`. The changes specify a branch for the submodule and update the submodule's commit reference.

### Git submodule configuration updates:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4): Added the `branch = dev` configuration to the `wormhole-docs` submodule, ensuring it tracks the `dev` branch.
* [`wormhole-docs`](diffhunk://#diff-1714e4e497bc7bb2c979e938c3e4844c20ece076b8f9c9d3c16237d1166619a7L1-R1): Updated the submodule commit reference from `119288a6e1f28f33cd689c071f43c7a812cbbd46` to `7ab3fc219ad9c38920a077667c8b22a838823870`.

wormhole-docs PRs:
- https://github.com/wormhole-foundation/wormhole-docs/pull/473
- https://github.com/wormhole-foundation/wormhole-docs/pull/544