### PR TITLE
Update sdk to the latest version 3.1.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.0.4",
+        "@wormhole-foundation/sdk": "3.1.0",
         "sharp": "^0.34.3",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",
         "markdown-link-check": "^3.13.7",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.2.tgz",
-      "integrity": "sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.14.0.tgz",
-      "integrity": "sha512-rgOJ0Bj9UFBmE7BfUGhsqYPYqPwCk1MCggoYN4NUSdX6gpqatNuzHNB2wHcAd9xdY55jHNRhHy5NsgwY6EGgmg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.0.tgz",
+      "integrity": "sha512-SReJAGmOeXrHGod+9Odqrz4s43liK0b2DFUetb/jmYvxFpWmeNfFYo0seCh0jz8vG3p1pnYMav0+Tm7XwWtOJw==",
       "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.15.0.tgz",
-      "integrity": "sha512-J1Iq42RSfW8M5XDVDF8ACz49RkrP/963Lgyi1Yn9e4P2CZ2kRhJm8KSfH++1+yyLbDCEVdGj4b63TK8DopGsTA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.16.1.tgz",
+      "integrity": "sha512-/6LWwZ/ZcC6/sI21s92cf3/8mgma6xRnBXtsF+708g2SX87WatJuXL8DjZsY1agCCnyw6bLVLtjKAfLQopNkxw==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.15.40.tgz",
-      "integrity": "sha512-K2ODP6O6ITvnDhr8sIHghhPNe3bzj5dUSWYikSm6ob13XRFv9banud8U/MbYRGHc9dGXZzAyWbPOyM2JlAKdog==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.1.tgz",
+      "integrity": "sha512-hcpMxbrnWZaK9RQwgNuAoL3CU1rznopf0Aj2Y4RIHMOs2hmJodfH9gY4Ju2zZOQKomjp0YLKdsLIs8fEZBr/eQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1099,12 +1099,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.15.41.tgz",
-      "integrity": "sha512-qL17XZ/u8rPZHyEYXnpSjQRNsUkpl2OJNusc4g/TcIz/wfd9p3mJUmEPmxdZWrxeO5cEqGr8FX2aCnE7hCB9/A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.1.tgz",
+      "integrity": "sha512-Rb1A3B4UAUA5YNl9w1aOOvijvop7nwt9MQQjUtcTjasoRrIc2gNlPtRIpcDcrcBnIPuMy4b1bP1CeeiOLgwtZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "^1.15.41"
+        "@injectivelabs/ts-types": "^1.16.1"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.15.43.tgz",
-      "integrity": "sha512-ROdADbd1VT+Erw8Cgr/ZyPAqr++MDrXeUHTMpMYdBLL5rdGU3xAwNN8zuHzO9iejVQ6KmYoXQvkRp1EFt/RncQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.1.tgz",
+      "integrity": "sha512-IugI94p2j4Vgadi+2VofQ1nUNC4/PdOZ8M1Q2RdZSqyPDerZSczYvPXdUER+nYQ7A4RXgs789a9GmMawtMVJsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -1160,17 +1160,17 @@
         "@cosmjs/proto-signing": "^0.33.0",
         "@cosmjs/stargate": "^0.33.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
-        "@injectivelabs/core-proto-ts": "1.15.0",
-        "@injectivelabs/exceptions": "^1.15.40",
+        "@injectivelabs/core-proto-ts": "1.16.1",
+        "@injectivelabs/exceptions": "^1.16.1",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.14",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "^1.15.41",
+        "@injectivelabs/networks": "^1.16.1",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "^1.15.41",
-        "@injectivelabs/utils": "^1.15.41",
+        "@injectivelabs/ts-types": "^1.16.1",
+        "@injectivelabs/utils": "^1.16.1",
         "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@apollo/client": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.8.tgz",
-      "integrity": "sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==",
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.9.tgz",
+      "integrity": "sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1374,21 +1374,21 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.15.41.tgz",
-      "integrity": "sha512-zyItZ6nxy/bf8hBWviPlqOt7EGKOLb/+6KF3t/fmMMy2NLi0k1UZQAy0V2MPBQ+1JjMYwfvC9ANMLsp4upHSsQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.1.tgz",
+      "integrity": "sha512-3gVGfocQCZ40ufxpOsuJozpYySGNTUzsgdytKqs/rqNm2Ddrjx0Jvxcfkq1fqjalY0lLdiiPXe/R8NfA+n/qpw==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.15.41.tgz",
-      "integrity": "sha512-zJoJB6iJGE/6nZ7jTPkagVoLsZousTb6QdddYOpM04rPiAkRCeKmYCICFI9veXsrdFNg4UKBqqLjF+cuYfSzQA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.1.tgz",
+      "integrity": "sha512-ng4dqwdJ9e4nt5765+w/23hP/f4M+d/g/fcPXzDFGhnf/y1jbmfOY96qXOxUBpLKc1DoItAoPlfmEBitVGLebg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "^1.15.40",
-        "@injectivelabs/networks": "^1.15.41",
-        "@injectivelabs/ts-types": "^1.15.41",
+        "@injectivelabs/exceptions": "^1.16.1",
+        "@injectivelabs/networks": "^1.16.1",
+        "@injectivelabs/ts-types": "^1.16.1",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.6.4.tgz",
-      "integrity": "sha512-HBBrqMtnVp5vy12efJYhj/HnOYGu+x5SqRQpnOJEHEkxypGZ01WNFoCNw7USzDSyJvPauhqdzUXzR+lYM1D5/g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.7.0.tgz",
+      "integrity": "sha512-8zE2Jzj2ai55RlVXx2pEMbbq+X3vB+uPGBvZr0F79IdTwuwcu4QdFG3PT/zHsytsvATkn+z0f2YDWhM5916u2A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/utils": "0.1.1",
@@ -1480,20 +1480,20 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.36.1.tgz",
-      "integrity": "sha512-3QmILnc2BpV8sdr5bfJpf6ipE4L6gnm8BDvE5Jk4W1WZPgWMAly39fYsOKCc4TYB013zwxRRStplHdBAGPwX8Q==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.1.tgz",
+      "integrity": "sha512-xkQEgO/XdGz9T5vJU0iEiw8ZnuDSHWjdYA+u783wY5dt0TknYDBBcThaufhz9j+tksCxKhR5OkktE+Wz3zdYtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.6.4",
+        "@mysten/bcs": "1.7.0",
         "@mysten/utils": "0.1.1",
-        "@noble/curves": "^1.9.1",
+        "@noble/curves": "^1.9.4",
         "@noble/hashes": "^1.8.0",
         "@scure/base": "^1.2.6",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "gql.tada": "^1.8.2",
+        "gql.tada": "^1.8.12",
         "graphql": "^16.11.0",
         "poseidon-lite": "^0.2.0",
         "valibot": "^0.36.0"
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
-      "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
+      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -1807,9 +1807,9 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.98.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.2.tgz",
-      "integrity": "sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==",
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.2.tgz",
-      "integrity": "sha512-fvA0JfSqWmJsq0FqLnl51DPRMqPer7hcIqqLwuhgAUOWrLVuJhmNeL+Y4Ds5PdoX/NyUhUWoflL6A7bT93Xfkg==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.3.tgz",
+      "integrity": "sha512-I+kNjW0udB4Fetr3vvtRuYZJS0PcSPyyvBcH5sDdoV8DFs5E4W2pTr7aiMlKfPxANTClP9RlqCPolj9dd5MsEA==",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -2057,52 +2057,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.0.4.tgz",
-      "integrity": "sha512-x5ONRl/y4nKFVVS2mGsvvNInXUwPB2UdWZW2KGFS9a8M2re/OCEhObv3GQ4snOnTuXVbKxlkRAmOIsFNtcichw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.1.0.tgz",
+      "integrity": "sha512-iIhiAYZFPKvQlm+b58gQeEL1CGrvHw34AwsKqcotlr11SaWWcB3rq+1L02NPY6E6+sWV4vvWUQmfxjvYV63hXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.4",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.4",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.0.4",
-        "@wormhole-foundation/sdk-aptos": "3.0.4",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.0.4",
-        "@wormhole-foundation/sdk-aptos-core": "3.0.4",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.0.4",
-        "@wormhole-foundation/sdk-base": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.0.4",
-        "@wormhole-foundation/sdk-definitions": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
-        "@wormhole-foundation/sdk-evm-cctp": "3.0.4",
-        "@wormhole-foundation/sdk-evm-core": "3.0.4",
-        "@wormhole-foundation/sdk-evm-portico": "3.0.4",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.0.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.4",
-        "@wormhole-foundation/sdk-solana": "3.0.4",
-        "@wormhole-foundation/sdk-solana-cctp": "3.0.4",
-        "@wormhole-foundation/sdk-solana-core": "3.0.4",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.0.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.4",
-        "@wormhole-foundation/sdk-sui": "3.0.4",
-        "@wormhole-foundation/sdk-sui-cctp": "3.0.4",
-        "@wormhole-foundation/sdk-sui-core": "3.0.4",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.0.4"
+        "@wormhole-foundation/sdk-algorand": "3.1.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.1.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-aptos": "3.1.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.1.0",
+        "@wormhole-foundation/sdk-aptos-core": "3.1.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-base": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-definitions": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-evm-cctp": "3.1.0",
+        "@wormhole-foundation/sdk-evm-core": "3.1.0",
+        "@wormhole-foundation/sdk-evm-portico": "3.1.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.1.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-solana": "3.1.0",
+        "@wormhole-foundation/sdk-solana-cctp": "3.1.0",
+        "@wormhole-foundation/sdk-solana-core": "3.1.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.1.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-sui": "3.1.0",
+        "@wormhole-foundation/sdk-sui-cctp": "3.1.0",
+        "@wormhole-foundation/sdk-sui-core": "3.1.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.0.4.tgz",
-      "integrity": "sha512-hGARh5mV72jNgcIque4gfjUm/8rgJoSyDoVyLELvRHYXpdCY1ctzXrQBD3ZPznQmHSvUX+Rz9Of3OdKYr151SA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.1.0.tgz",
+      "integrity": "sha512-RBK3t+RlZbz8VggguZflEoX+XerTAzYg8rDXfcSO2WLew9Ao4SJb45oAdWuBNuIRenMKobo7QhVg4VCPBrr1Tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2110,89 +2110,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.0.4.tgz",
-      "integrity": "sha512-tWp3cbiG6oadwphsbW8WemW5HYo5TnLweP2iGsxJn9PI/DfUMu9sd+zCVuobXMvmpS9JM/z48XgJr7R57lQJkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.1.0.tgz",
+      "integrity": "sha512-NTVHQ31bwtkNQuYgrYJAbVokYKA1+nx5lVdZXShT+qNBHzko9IZdxGquEKc7uMorBmKhfrOYVZS4y+j+ToImdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-algorand": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-mA0Pft71sddrlwRmV47VTgULhcQYZVDR9OLg694EIPkUKjycrNHWE1G/IdaMHdzScVM5TulcA0DlJ0QikA3MJg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-k9OIPsaNnjins0gGa7OguwCirSLnREh7bExaODCYmPFvkhea6SObYkOn4VMro6OeK+wRiG04wWlsAZeY8HtLuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.4",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-algorand": "3.1.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.0.4.tgz",
-      "integrity": "sha512-ZEG6Yv0UQyO/m6oh8ohM1KK1myMOkA7LFCF1JUybGSrP3f3O9keoktrqtbJTOHZlp7C9Ck9Xyc0HLKCRWqidyg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.1.0.tgz",
+      "integrity": "sha512-Flkh3Gwwm7rWLsbwJNnshhV5A4Ab6Y28CsRuFvxaxGOlJMe64npYTqYlae1JPFr/uXHsuUdi+Xgy+IRmgt5S5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.0.4.tgz",
-      "integrity": "sha512-CExb3ZCSEJUOHs/NMJcZOX9RB39pqXbsCQHJkSnI0TCY/YpWX+XBRfC1cg311dg5gOhff1l7RGvO/dRpFgvOoQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.1.0.tgz",
+      "integrity": "sha512-my92ajZHk4jE5XY/J1yjsMy597RdO6j7kuaD33Tap8o9uLBf7V6ycIsyhNA8grMFpJ7LhQlCH+ttKXW3UgV8qA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-aptos": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.0.4.tgz",
-      "integrity": "sha512-m4pj0aWLRgUCJaYitcZ8y1w4ZMyGlxfd3zU3PxgBuycOc7QLvK7BiTE8cMASFzbFTFkC7B3aPg4EgUGY3C+iEg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.1.0.tgz",
+      "integrity": "sha512-gD2YLLKU8kW6hRm6+q8V1O2INKah+TFIARMJPmNDoUfid7ssO1FeYh4vsHFbHQcvETGYitcL0aR4pzpOTcctEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-aptos": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-7GVr7DHeDY13O8CLHRCbYajx24C7Zju6I9RJuyTQPIocRycToA6f5AuHJGhlIMXXzI0O3hNnGJe9Ie55FaHAHQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-8a0Frjgrl8/Vkj9cVSY68CfaEnK18zcjdB7RCmxVawDRyjDNj0a1IJbHzCLQQohk986SinZG0id4ZlvgsF+8qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.4",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-aptos": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.0.4.tgz",
-      "integrity": "sha512-pOT81IiFDxLNWgQrBXCuSjkUj0No1uGzxXeDaUPe2IhvteA52LviIsKzTgWkm4/Rqer+iXYehfR7LgYcUcVb6A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.1.0.tgz",
+      "integrity": "sha512-RFapDWAD2+D4cf6uy6VSf212qemUjnSsgLEJ8HWa2ezrmEM8BWlztmknlO3+NP2th74Ice6qwQAfX/Jl9J013g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2200,13 +2200,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.0.4.tgz",
-      "integrity": "sha512-1xPzUzbysySWgOtegxOgiGs2iRZCL//sfFYiTb55T7ae9tQQjMypq2KOLn/XlbLzR50y6zgqEVQ0l7RpewXZWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.1.0.tgz",
+      "integrity": "sha512-t5xTwV0GRZKTtWre7IFcQgL77ZnQEX8RZab4IM5QtAYmlg/v/48MLiTKINOgc/1FGegEG872qWN/MD0D2Ofalw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.0.4",
-        "@wormhole-foundation/sdk-definitions": "3.0.4",
+        "@wormhole-foundation/sdk-base": "3.1.0",
+        "@wormhole-foundation/sdk-definitions": "3.1.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2214,16 +2214,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.0.4.tgz",
-      "integrity": "sha512-ng3CzqoOIZ506iUa8p8dr7w+LDQLRO9jXruVRg9BsHXj5Ah6VdEKkloWhQ6Q8n1hqDsFnA3EWAUY5cmQt5ihLg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.1.0.tgz",
+      "integrity": "sha512-8efewYELt8WWONK4P+3l5HKSZL4NbO+oGXXMJASNvdLgqO2u0bl3Ay3IRf92pFlUeUetWolcHhNeS/jV75I3aA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2231,33 +2231,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.0.4.tgz",
-      "integrity": "sha512-YnlE1dd5ylSFdZSEYJJNPBrcEc6xoSwPZmNHJFO9RdG3HAtI1y99C8yv2AXaFiNnIu5XeGe6AW26O1n0RL2tow==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.1.0.tgz",
+      "integrity": "sha512-pOyh6TlWleMnY66OxYX4K8Ei4Rc0vPj+X9chZnArwbIwhrcWuogMSKk74PaX4+blB4WLlv31P1PghxpliZCA/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.0.4.tgz",
-      "integrity": "sha512-0SmW5b8bqS4Gok4kKe1dpFivAVTwwpoGJlOQbFzWoLuFmpVgc/X1CuDsmPUQ98WUAmsXghlPM5y+emysqOpnag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.1.0.tgz",
+      "integrity": "sha512-YixWspsv4FQzQ3tbxEyUHPDaYANB3tY6EJp4o+eBqkLyEfR9lDVSCvYApQGWhQreFre96t+cJ+Xa4hi8Kwz6yw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.1.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2265,37 +2265,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-HF0FttFxKnqf52BO3Q8dddsLwI84wItMDxfD2uDi4FbOxVRrsGMcYmDqfMdexhHwz3cZ26JLYUgkkizn/tW2vg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-IctjmENhtqPygW/0kMWLESTTa3UzZFSJYp5Y366v3II9oeLSRAQL4TrzK9R+s4U8pXgWXPTWMcMnb5BeYZPqdw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.0.4.tgz",
-      "integrity": "sha512-e8E8AwHMc7dXHqjG13xjxZ7DMWLszlfLpfEuPUWpuYURc7dZgODfrlA3bXx1A1kFKnppOMdrjBqVGHwFa9gsDg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.1.0.tgz",
+      "integrity": "sha512-TOfc8swkdPEkJLqc/3yCnXhGvqjTe5hBRyziXHq2Pd2WMmfr9VvAFCDYVfku3803aNDpzasDWCSc01+chQKbYA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.0.4"
+        "@wormhole-foundation/sdk-base": "3.1.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.0.4.tgz",
-      "integrity": "sha512-GON+V03YiJ2LSWF95IZ/8LDcp2bAp2hu9dA+SAPI1FwFLawXDRsQt4nmghcefrS4DRKDViRQiKO+gB78P4pzsw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.1.0.tgz",
+      "integrity": "sha512-iQ3lX94cA1W9m3ytSsKSnxrID+qo9h5YfDwrsKQTRY1BR7/WS3qyRv60+gclxY0UbQZGnAQEf+lJmVTeIzXcjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2303,14 +2303,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.0.4.tgz",
-      "integrity": "sha512-pg8JwCAddbmFN8Ik4OMzEgWN1Zqh/IWBN2uSWz2JUe97x8rYScU3A83tXR+iriKsxM8v5vqpadXdo90zsrLXrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.1.0.tgz",
+      "integrity": "sha512-inaF2LsKg/YO2agai0BA8ArKrS6eYsc0sGzHxHX1+yKwfTyiO8ZqCyXehnZTMNIp1a3BsBchcOYJkGqv5SF1qA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
-        "@wormhole-foundation/sdk-evm-core": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-evm-core": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2318,13 +2318,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.0.4.tgz",
-      "integrity": "sha512-+2nRpYyeKoCvbiZkwhBxIk+e4g9CKZOwEZAhIpl1luNsr9h/QU8E/n2ZlpstlObgs1DHmG8/BzjeKyTIcidCRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.1.0.tgz",
+      "integrity": "sha512-P3lVUyaN35I0IN6oT5NAorY6Eay2hbfPKXxCXp71wPhBSEPb1PLX1vIYBUMnx/M20UlIJbvTrcCuU+Jpp+iZkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2332,15 +2332,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.0.4.tgz",
-      "integrity": "sha512-j1F7xAMjms2PKnyJCL3h8JQg8bkFPyD9L+QpQ4I0zkQh67FtoVuXjssxlhZC4ljCEigdQpAxuKtFZO5XWptdSg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.1.0.tgz",
+      "integrity": "sha512-yR/0E+W6VVk5paAzY6qKyFIkRzYaqej1g6ne4Cx7ABlGS20/2mrPPu2aHIC6Euy4GOyDUOCjUqGasv8yeFqXvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
-        "@wormhole-foundation/sdk-evm-core": "3.0.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-evm-core": "3.1.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2348,14 +2348,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.0.4.tgz",
-      "integrity": "sha512-74ODZFX1t8XsKFpc/saKE9/9e8vdDN7shMP/MMEGs6oGoZsZE3jaXiegjJFcxCbeGwNXS2czOsZCcgjCAIt25w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.1.0.tgz",
+      "integrity": "sha512-VLP1gqOXNEgd57DEB9gt5dOjmpvreX1Qex2bQLd0ubeqNlZ6aRp6J4TCl9UVX/yGRyrnlGvMuD1xA+e5CDvUYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
-        "@wormhole-foundation/sdk-evm-core": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-evm-core": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2363,14 +2363,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-ECGhTtVBEea2oH5hcr9k3Dv5oWw+Xes+N8EhvaQhqIgkHcxeBlLm7lyFXQrtDM4oCd8ywWf4B72esi+yXsnbWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-EDVd1r8n/DSejWYP3AgdF2nx2kqeYOJnReFhlX+lZ6F559gi34mdaZuxmqvLg4TzcuEOmEwOfixW/qFF8ro0tQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-evm": "3.0.4",
-        "@wormhole-foundation/sdk-evm-core": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-evm-core": "3.1.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2378,16 +2378,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.0.4.tgz",
-      "integrity": "sha512-lltwLFJp+swvX6uqASGt/V+3F33itL9WuxfRp78I05E6x9q1Y+A9idCd2mOvroeBmcFEz1gW/vY8rgB9s6kHrQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.1.0.tgz",
+      "integrity": "sha512-vZH6qrPl/s3/97v/caZY7G7AO1w3mX8urcxF2/6DWWMmk0Ld2UiviI6yjndtOjryza/wrMHOUxoghhSM8hIo1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
+        "@wormhole-foundation/sdk-connect": "3.1.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2395,123 +2395,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.0.4.tgz",
-      "integrity": "sha512-BLuoUnInJgmn4M3ElUXmMtx9yynsicm4iwVZ/pvkTCHtPFcjzbciqQilgl8hzmtXCgBrwYKNuI4OVx1UZky2yQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.1.0.tgz",
+      "integrity": "sha512-QDQoMGW76yGtSpJQ99De1X+XFs5BNKcBcQcsKguO/ks+CeMiA6Lw0seWKcHfWPYjlzPga5jJN2Dh/Y/59YtNMw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-solana": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-solana": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.0.4.tgz",
-      "integrity": "sha512-5HC3zwfdyloU7gKSMOocGqCT9O4KzI4shdgz/cwPe6AStEgrxhaCHTeRogCJuuWGII+wGTIg3WG7TorPqd3+CA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.1.0.tgz",
+      "integrity": "sha512-0PwtGnHqGUgNPO9sDi/4EYOlGuNWLXvTETO8iWZpxR+5IHSDudk61G4FNq/CLjpnRs7LU1cPdH5McmVjT6KlAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-solana": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-solana": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.0.4.tgz",
-      "integrity": "sha512-yKITAEIaGI1CnfEkUfYdB29osLtKOZCGZoJCMluJiRGTHxg1W3N6mBPmzMznTtykeZGqcMlZNKRAFenj/U+oHg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.1.0.tgz",
+      "integrity": "sha512-77Rg0KQRvPJBse79SbdtdnDWR6c2XNiG7VJSZUVNuTWF37evOwJMjNg5t5e4S6HH+E70SjMmcn1FSBiklTxipQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-solana": "3.0.4",
-        "@wormhole-foundation/sdk-solana-core": "3.0.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-solana": "3.1.0",
+        "@wormhole-foundation/sdk-solana-core": "3.1.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-dpPJAgrGoVp3oSargRWqI9voRMOLMpgWxQCWdqV1/rEaluB6PQAOR4SdLXMSL72jFQOFoHAEaEY6AnlC6XTFTQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-ow4wKXle2GN325bNAelkqjvn96BpLHZ6bOROOlTqkJuAFOM4XVKs6Oh/MKxU77B0qg2YnhGjRzaCRz72TbPoLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-solana": "3.0.4",
-        "@wormhole-foundation/sdk-solana-core": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-solana": "3.1.0",
+        "@wormhole-foundation/sdk-solana-core": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.0.4.tgz",
-      "integrity": "sha512-rkshbxhANI1PPaoUSh99vdA18nseelvBDxTdQ80ZmYXlUBOlCNwvgqb4PQvRrvkWVXKDqiFosCaQPaLNEIgXMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.1.0.tgz",
+      "integrity": "sha512-x6A7fMx8XB/zwIh81lVnOhGzgh6KLrXCy1P1DMzGMTdjOuun5DFEjuFQBlnOyaM/+fxDS9VoXK/rHdaik+xoXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.0.4.tgz",
-      "integrity": "sha512-RGSBQ/6Hx4my99fnw7mpDPq/JgoVxrsdgZUBUWR1B89Hr+2imZN5bRWk8gIE9I+BYm6ZpfsYxJYSeTK5/wFGKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.1.0.tgz",
+      "integrity": "sha512-LlZSNoIRBOzD5ARCM8yDjdq2gHA4wHGkWpiTrWUt7Y0AMqHasXEScTQeQc4qK5n2Zo0C8QXxa7c0UHeClCcNJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-sui": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-sui": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.0.4.tgz",
-      "integrity": "sha512-bNtI/aBtCLr8+LqSn0RFwU/0lPTCTPoMW7OCP2FVmD+M+MVvX4SsTt6lRh15EA5J7KlSZO1olNsv2FImhx47GA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.1.0.tgz",
+      "integrity": "sha512-KOcs2v8fZlYqozPKLxVvfFzGljefmCw/CCrjl6Zat9VdIFlPfgSnG9g7OIOpqzco9fsW4XYKoQKuOUB3VgXgMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-sui": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-sui": "3.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.0.4.tgz",
-      "integrity": "sha512-FKChO8gXxHcePHxA2SP/DVQwmffoVn4Jj1ev8+Xhtz/t6kH2DLqEFS1n3oBKFbMv3nML+fqEa8ma2uxivApBTA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.1.0.tgz",
+      "integrity": "sha512-YZDjuYeLiIoorXcu4T1p2Ory7rWadk6yx9p5+RIbu6KSjVs9p82p2/imAERSZS8/Rlam3VgKHA7X1DiASQCQMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.4",
-        "@wormhole-foundation/sdk-sui": "3.0.4",
-        "@wormhole-foundation/sdk-sui-core": "3.0.4"
+        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-sui": "3.1.0",
+        "@wormhole-foundation/sdk-sui-core": "3.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -3935,9 +3935,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -6136,9 +6136,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,10 +15,10 @@
   "devDependencies": {
     "@types/node": "^24.1.0",
     "markdown-link-check": "^3.13.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.0.4",
+    "@wormhole-foundation/sdk": "3.1.0",
     "sharp": "^0.34.3",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/chains/Mezo.json
+++ b/scripts/src/chains/Mezo.json
@@ -29,7 +29,7 @@
       "devnet": true
     },
     "ntt": {
-      "mainnet": false,
+      "mainnet": true,
       "testnet": true,
       "devnet": false
     }

--- a/scripts/src/chains/Plume.json
+++ b/scripts/src/chains/Plume.json
@@ -14,6 +14,11 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
     }
   },
   "devDocs": "https://docs.plume.org/plume",

--- a/scripts/src/generated/ntt-support.json
+++ b/scripts/src/generated/ntt-support.json
@@ -19,6 +19,8 @@
     "Ink",
     "Worldchain",
     "Unichain",
+    "Mezo",
+    "Plume",
     "Solana"
   ],
   "Testnet": [


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration changes for blockchain network settings in the `scripts` directory. The key changes involve upgrading package versions, modifying network availability for the `Mezo` chain, and adding a new network type (`ntt`) to the `Plume` chain.

### Dependency Updates:
* [`scripts/package.json`](diffhunk://#diff-d74f97384f03053c517e34bcd695eefd751944cd55183d693ae99ef3bc50d016L18-R21): Upgraded `typescript` from `^5.8.3` to `^5.9.2` and `@wormhole-foundation/sdk` from `3.0.4` to `3.1.0`.

### Blockchain Network Configuration:
* [`scripts/src/chains/Mezo.json`](diffhunk://#diff-31a81a9f5fdf85d10eccb674c8703c58b3a0960059b6e03f0849a1baffc26b4aL32-R32): Updated the `ntt` network configuration to enable `mainnet` while disabling `testnet` and `devnet`.
* [`scripts/src/chains/Plume.json`](diffhunk://#diff-181d45f5cd0e2b1a0cd01b4e53fa45f9c5ba700b7247ffbd8dc8ba49eb93cb7fR17-R21): Added a new `ntt` network configuration with `mainnet` enabled, `testnet` disabled, and `devnet` disabled.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/551