### PR TITLE
Martinh/update sdk v3.2.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.1.0",
+        "@wormhole-foundation/sdk": "3.2.0",
         "sharp": "^0.34.3",
         "swagger-markdown": "^2.3.2"
       },
       "devDependencies": {
-        "@types/node": "^24.1.0",
+        "@types/node": "^24.2.0",
         "markdown-link-check": "^3.13.7",
         "typescript": "^5.9.2"
       }
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.0.tgz",
-      "integrity": "sha512-Jj74qfIplT+MzUUWABeUJxHF5lxiyOJpE4ENeIOwvcPAi+QYoxsKNj/aPcGAk2jK5CrP9aFtE5O7794q2rWjlQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.1.tgz",
+      "integrity": "sha512-wg5ysZNQxtNQm67T3laVWmZzLpGb7QfyYWZdaUD2r1OjDj5Bgftq7eQlplmH+hsdffjuUyhJw/b5XAjeE2mJtg==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.1.tgz",
-      "integrity": "sha512-hcpMxbrnWZaK9RQwgNuAoL3CU1rznopf0Aj2Y4RIHMOs2hmJodfH9gY4Ju2zZOQKomjp0YLKdsLIs8fEZBr/eQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.2.tgz",
+      "integrity": "sha512-+pOo/v+pG5IE1X29LJsMqrFa3KRXF0hxmqn21RhPTIHyxOlSpSBmPqYoH/xR9RDr2zfVgzxH3S4tymJtVRhBqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1099,12 +1099,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.1.tgz",
-      "integrity": "sha512-Rb1A3B4UAUA5YNl9w1aOOvijvop7nwt9MQQjUtcTjasoRrIc2gNlPtRIpcDcrcBnIPuMy4b1bP1CeeiOLgwtZw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.2.tgz",
+      "integrity": "sha512-RSuaUcvws23shffGJIgEuzrEoV1LUXtf7n5VDxGc3uZadtbctGPVakQZKNxjzyzaAn97yFxTI44+y8Bu7014GA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "^1.16.1"
+        "@injectivelabs/ts-types": "^1.16.2"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.1.tgz",
-      "integrity": "sha512-IugI94p2j4Vgadi+2VofQ1nUNC4/PdOZ8M1Q2RdZSqyPDerZSczYvPXdUER+nYQ7A4RXgs789a9GmMawtMVJsA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.2.tgz",
+      "integrity": "sha512-tkXElQMLu42dR1TQ/xbRhMegBWiZfN12zFektBvnXzNV6VFttPp4ERDGnvFSAScblrQyKMARi3lDtw22tDwDIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -1161,16 +1161,16 @@
         "@cosmjs/stargate": "^0.33.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
         "@injectivelabs/core-proto-ts": "1.16.1",
-        "@injectivelabs/exceptions": "^1.16.1",
+        "@injectivelabs/exceptions": "^1.16.2",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.14",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "^1.16.1",
+        "@injectivelabs/networks": "^1.16.2",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "^1.16.1",
-        "@injectivelabs/utils": "^1.16.1",
+        "@injectivelabs/ts-types": "^1.16.2",
+        "@injectivelabs/utils": "^1.16.2",
         "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
@@ -1374,21 +1374,21 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.1.tgz",
-      "integrity": "sha512-3gVGfocQCZ40ufxpOsuJozpYySGNTUzsgdytKqs/rqNm2Ddrjx0Jvxcfkq1fqjalY0lLdiiPXe/R8NfA+n/qpw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.2.tgz",
+      "integrity": "sha512-/0YETj+eu3h18OjxkUtqmMCLto9VuYEpuvE2rdmz+PQNQrqOJNJyKQnOH9zYW9tGrjBCD6w+LdHkP980I1V1fg==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.1.tgz",
-      "integrity": "sha512-ng4dqwdJ9e4nt5765+w/23hP/f4M+d/g/fcPXzDFGhnf/y1jbmfOY96qXOxUBpLKc1DoItAoPlfmEBitVGLebg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.2.tgz",
+      "integrity": "sha512-vPrm50x3BYLblnLJCmMVwoXEg3qvkjP53eiiCx6vG3mrqOVzf1YPJVZDBG0ZipkFhxkBjCjj/T8LdHUoVbz9bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "^1.16.1",
-        "@injectivelabs/networks": "^1.16.1",
-        "@injectivelabs/ts-types": "^1.16.1",
+        "@injectivelabs/exceptions": "^1.16.2",
+        "@injectivelabs/networks": "^1.16.2",
+        "@injectivelabs/ts-types": "^1.16.2",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
@@ -2005,12 +2005,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/pbkdf2": {
@@ -2057,52 +2057,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-iIhiAYZFPKvQlm+b58gQeEL1CGrvHw34AwsKqcotlr11SaWWcB3rq+1L02NPY6E6+sWV4vvWUQmfxjvYV63hXA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-4B2xyPPbpWLXGIOEwGbURqoWu31h/CXIXaN+jt11SiQx2o4eNDt64K8TAHjsQ0VfaGq7wsD5QJ5nmDpY0NEcNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.1.0",
-        "@wormhole-foundation/sdk-algorand-core": "3.1.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.1.0",
-        "@wormhole-foundation/sdk-aptos": "3.1.0",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.1.0",
-        "@wormhole-foundation/sdk-aptos-core": "3.1.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.1.0",
-        "@wormhole-foundation/sdk-base": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.1.0",
-        "@wormhole-foundation/sdk-definitions": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
-        "@wormhole-foundation/sdk-evm-cctp": "3.1.0",
-        "@wormhole-foundation/sdk-evm-core": "3.1.0",
-        "@wormhole-foundation/sdk-evm-portico": "3.1.0",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.1.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.1.0",
-        "@wormhole-foundation/sdk-solana": "3.1.0",
-        "@wormhole-foundation/sdk-solana-cctp": "3.1.0",
-        "@wormhole-foundation/sdk-solana-core": "3.1.0",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.1.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.1.0",
-        "@wormhole-foundation/sdk-sui": "3.1.0",
-        "@wormhole-foundation/sdk-sui-cctp": "3.1.0",
-        "@wormhole-foundation/sdk-sui-core": "3.1.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.1.0"
+        "@wormhole-foundation/sdk-algorand": "3.2.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.2.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-aptos": "3.2.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.2.0",
+        "@wormhole-foundation/sdk-aptos-core": "3.2.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-base": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-definitions": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-evm-cctp": "3.2.0",
+        "@wormhole-foundation/sdk-evm-core": "3.2.0",
+        "@wormhole-foundation/sdk-evm-portico": "3.2.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.2.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-solana": "3.2.0",
+        "@wormhole-foundation/sdk-solana-cctp": "3.2.0",
+        "@wormhole-foundation/sdk-solana-core": "3.2.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.2.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-sui": "3.2.0",
+        "@wormhole-foundation/sdk-sui-cctp": "3.2.0",
+        "@wormhole-foundation/sdk-sui-core": "3.2.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.1.0.tgz",
-      "integrity": "sha512-RBK3t+RlZbz8VggguZflEoX+XerTAzYg8rDXfcSO2WLew9Ao4SJb45oAdWuBNuIRenMKobo7QhVg4VCPBrr1Tg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.2.0.tgz",
+      "integrity": "sha512-L8PMH6VnroNFLj637x//Z8U4f5U+4D3lXoWm28kMRcanJa8fFcOu6gVjjIAsIO9avf9AQTXqvmUR9lUNvDh+sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2110,89 +2110,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.1.0.tgz",
-      "integrity": "sha512-NTVHQ31bwtkNQuYgrYJAbVokYKA1+nx5lVdZXShT+qNBHzko9IZdxGquEKc7uMorBmKhfrOYVZS4y+j+ToImdA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.2.0.tgz",
+      "integrity": "sha512-CAGLZddbKjx2fa0H6ols3oIHmNq5WqmNG1N6NbsFaiNaLMNHeD0gMUTXrmSesN43gO9z1RleBH9otmrw2k7H5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-algorand": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-k9OIPsaNnjins0gGa7OguwCirSLnREh7bExaODCYmPFvkhea6SObYkOn4VMro6OeK+wRiG04wWlsAZeY8HtLuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-Q2RM/Mzp5VmFdo734HupAGLud11Z0h6cMibuAqZWCfPfe5GHsvGEqyPCarzPWBKvoas6SqPIRZ+VY8fMoyBPCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.1.0",
-        "@wormhole-foundation/sdk-algorand-core": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-algorand": "3.2.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.1.0.tgz",
-      "integrity": "sha512-Flkh3Gwwm7rWLsbwJNnshhV5A4Ab6Y28CsRuFvxaxGOlJMe64npYTqYlae1JPFr/uXHsuUdi+Xgy+IRmgt5S5Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.2.0.tgz",
+      "integrity": "sha512-norK+UcreLCKWMchGLF6gfRGbdWWa2x+yEfFIcO1/3oko68UYefwJhoP/mptMX1dqgoX2wTqMu9Hwt3zwMmO3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.1.0.tgz",
-      "integrity": "sha512-my92ajZHk4jE5XY/J1yjsMy597RdO6j7kuaD33Tap8o9uLBf7V6ycIsyhNA8grMFpJ7LhQlCH+ttKXW3UgV8qA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.2.0.tgz",
+      "integrity": "sha512-U0Jsca97ZESWMPAoBnIMh1MCvn9j/1Yy+obV2/WPANRlFpF6O8VeTiyIRv0vCg14/WjBV5zqtBsNzxda6Zc3UQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-aptos": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.1.0.tgz",
-      "integrity": "sha512-gD2YLLKU8kW6hRm6+q8V1O2INKah+TFIARMJPmNDoUfid7ssO1FeYh4vsHFbHQcvETGYitcL0aR4pzpOTcctEA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.2.0.tgz",
+      "integrity": "sha512-9jJkDqAGWdRWS8mzc2k/vUW3McZ+Yqt3wtzX8CuqqEv8QGidli4Rm00nzvif6O0dIE+HmmGwpWmJlZ7jJ4sSZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-aptos": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-8a0Frjgrl8/Vkj9cVSY68CfaEnK18zcjdB7RCmxVawDRyjDNj0a1IJbHzCLQQohk986SinZG0id4ZlvgsF+8qw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-3tZsdY4IvEYnce579MzCqK1XoqJqA5D7PnN/XV/7AA0VCJq7hjWmZksfkR4DRCsUKr2sl/T6+wYOof0AtQV1sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.1.0",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-aptos": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.1.0.tgz",
-      "integrity": "sha512-RFapDWAD2+D4cf6uy6VSf212qemUjnSsgLEJ8HWa2ezrmEM8BWlztmknlO3+NP2th74Ice6qwQAfX/Jl9J013g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.2.0.tgz",
+      "integrity": "sha512-Ss90qA3Da48Lu0VCrXA4di3r9IT/a6w6mUBU8dLYEZcCsllWP864Ru/no22C57Kash2uo4KB3TgPLnEi5iCqbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2200,13 +2200,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.1.0.tgz",
-      "integrity": "sha512-t5xTwV0GRZKTtWre7IFcQgL77ZnQEX8RZab4IM5QtAYmlg/v/48MLiTKINOgc/1FGegEG872qWN/MD0D2Ofalw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.2.0.tgz",
+      "integrity": "sha512-vc7RKLiO715qMoEkHhFVfuVg2AmUBCUj8gnw84PwOn6PYZKxQpYvZfgKKztvL1GDfaO+R3+nT8WxfSemLK0R3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.1.0",
-        "@wormhole-foundation/sdk-definitions": "3.1.0",
+        "@wormhole-foundation/sdk-base": "3.2.0",
+        "@wormhole-foundation/sdk-definitions": "3.2.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2214,16 +2214,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.1.0.tgz",
-      "integrity": "sha512-8efewYELt8WWONK4P+3l5HKSZL4NbO+oGXXMJASNvdLgqO2u0bl3Ay3IRf92pFlUeUetWolcHhNeS/jV75I3aA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.2.0.tgz",
+      "integrity": "sha512-uH76AyBF00VObYoOcdYBY4fHGI5WXzlGTrAuM8IV2oX9oYjA9MrCyzP4vVfeleWJRPB8ZY+7cOz6keS/ngMD8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2231,33 +2231,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.1.0.tgz",
-      "integrity": "sha512-pOyh6TlWleMnY66OxYX4K8Ei4Rc0vPj+X9chZnArwbIwhrcWuogMSKk74PaX4+blB4WLlv31P1PghxpliZCA/A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.2.0.tgz",
+      "integrity": "sha512-9Rko/UcSIpIyG4blx85zQf8OMFXBrx9qcqKGF9Q0voQJED3ldMtQtXHkWF/8pg3sjTuzmdLltxFBwy3uHWNN1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.1.0.tgz",
-      "integrity": "sha512-YixWspsv4FQzQ3tbxEyUHPDaYANB3tY6EJp4o+eBqkLyEfR9lDVSCvYApQGWhQreFre96t+cJ+Xa4hi8Kwz6yw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.2.0.tgz",
+      "integrity": "sha512-6u+HMzv8nck8W++jO0qgc60ILODTXmHCIGq/dwLWyov50gZ23LXG9Uz1ZwFVy1Ja7wm2u6hInRFoXXlF1tSW/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.2.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2265,37 +2265,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-IctjmENhtqPygW/0kMWLESTTa3UzZFSJYp5Y366v3II9oeLSRAQL4TrzK9R+s4U8pXgWXPTWMcMnb5BeYZPqdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-KiUnLcoxv9yZ6Eh5c/X+iK31OiiMAME+Cr47gyntbs5pLDuGJIVQRLVXjqTer0KleIobunReLXaIVsyrX9tchQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.1.0.tgz",
-      "integrity": "sha512-TOfc8swkdPEkJLqc/3yCnXhGvqjTe5hBRyziXHq2Pd2WMmfr9VvAFCDYVfku3803aNDpzasDWCSc01+chQKbYA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.2.0.tgz",
+      "integrity": "sha512-6HPDxFM6dmtVqs6JDETIXLsm0evgRhOOGAoFI48BgJJiYJwDZApfJHOo02dN0wPVYiWQdNDRCevS/sGSM9dSVA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.1.0"
+        "@wormhole-foundation/sdk-base": "3.2.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.1.0.tgz",
-      "integrity": "sha512-iQ3lX94cA1W9m3ytSsKSnxrID+qo9h5YfDwrsKQTRY1BR7/WS3qyRv60+gclxY0UbQZGnAQEf+lJmVTeIzXcjQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.2.0.tgz",
+      "integrity": "sha512-HtNSPIQDV37VJFSi82ndy4KQ/ELmp7RHrgX/HTzOQ+tKoRjTvdwSrjZRMsVEPJTA+FNbS+WXpQ9Aeotdg7eMHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2303,14 +2303,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.1.0.tgz",
-      "integrity": "sha512-inaF2LsKg/YO2agai0BA8ArKrS6eYsc0sGzHxHX1+yKwfTyiO8ZqCyXehnZTMNIp1a3BsBchcOYJkGqv5SF1qA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.2.0.tgz",
+      "integrity": "sha512-OfuD59KrpKpe4keD/4xD0CKo5938efL6BotsfuJf7LnWiB/sL9HHjuBQebH3X7ymSHGeMuUm0Ah/8TPF3jRa7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
-        "@wormhole-foundation/sdk-evm-core": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-evm-core": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2318,13 +2318,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.1.0.tgz",
-      "integrity": "sha512-P3lVUyaN35I0IN6oT5NAorY6Eay2hbfPKXxCXp71wPhBSEPb1PLX1vIYBUMnx/M20UlIJbvTrcCuU+Jpp+iZkg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.2.0.tgz",
+      "integrity": "sha512-5GRyC+oHY4Am7jnw+KFrWNWSxE/tO8VzIH5qBeHLhnxevpx7a87SC8FLGn6m88kT+CAQohqmnlwwtsFkQsBtZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2332,15 +2332,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.1.0.tgz",
-      "integrity": "sha512-yR/0E+W6VVk5paAzY6qKyFIkRzYaqej1g6ne4Cx7ABlGS20/2mrPPu2aHIC6Euy4GOyDUOCjUqGasv8yeFqXvw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.2.0.tgz",
+      "integrity": "sha512-W/Y5k82B6G4UBKLArK8MhmfLZ1h1bOioRbqi8MYcYoW+Gte5jBZ3rrKHHAQTXe2VO2cg/4kJS9HCb7GLM3vWbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
-        "@wormhole-foundation/sdk-evm-core": "3.1.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-evm-core": "3.2.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2348,14 +2348,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.1.0.tgz",
-      "integrity": "sha512-VLP1gqOXNEgd57DEB9gt5dOjmpvreX1Qex2bQLd0ubeqNlZ6aRp6J4TCl9UVX/yGRyrnlGvMuD1xA+e5CDvUYA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.2.0.tgz",
+      "integrity": "sha512-JY1Ord+Rd6xkY03cG/6purLE5qIG3jy8qwwjmq6oQl2aDcKHx34mO5lsAoon3B7MG3uWXBsRDaspsMR25//pPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
-        "@wormhole-foundation/sdk-evm-core": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-evm-core": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2363,14 +2363,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-EDVd1r8n/DSejWYP3AgdF2nx2kqeYOJnReFhlX+lZ6F559gi34mdaZuxmqvLg4TzcuEOmEwOfixW/qFF8ro0tQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-AYTShYueKWl01ijL99o9+LHbqAFI+h8v1jS7x5wXC2TftbpHfWKmNFiginWCZOeCKmR3HXirLZFkeJN702ANzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-evm": "3.1.0",
-        "@wormhole-foundation/sdk-evm-core": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-evm-core": "3.2.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2378,16 +2378,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.1.0.tgz",
-      "integrity": "sha512-vZH6qrPl/s3/97v/caZY7G7AO1w3mX8urcxF2/6DWWMmk0Ld2UiviI6yjndtOjryza/wrMHOUxoghhSM8hIo1Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.2.0.tgz",
+      "integrity": "sha512-YzPYgDyzlQ+3/wLQq1kfo6F9kfLTp9tY2bw2QXVP6EdibY0vLQuAfpfuboXGGKNpZkdV/ACpe1MJM+MxXIDu5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
+        "@wormhole-foundation/sdk-connect": "3.2.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2395,123 +2395,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.1.0.tgz",
-      "integrity": "sha512-QDQoMGW76yGtSpJQ99De1X+XFs5BNKcBcQcsKguO/ks+CeMiA6Lw0seWKcHfWPYjlzPga5jJN2Dh/Y/59YtNMw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.2.0.tgz",
+      "integrity": "sha512-qc59CHWu+ZGpG3iAyS2dwHqnySKuclI952sihAbQ+13rcqAfCnYKXl+dPnOD+53RMi2/F4MgHSyMPbjwDwKf+Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-solana": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-solana": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.1.0.tgz",
-      "integrity": "sha512-0PwtGnHqGUgNPO9sDi/4EYOlGuNWLXvTETO8iWZpxR+5IHSDudk61G4FNq/CLjpnRs7LU1cPdH5McmVjT6KlAA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.2.0.tgz",
+      "integrity": "sha512-3Q1t8KmWhD5+5vvlLcLtUHyPWmoCq2ytfEa4ZctDSIG+oXEj20mVEGvolz2FJkHFi0cgB0/z1U0tcVWT7gPjRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-solana": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-solana": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.1.0.tgz",
-      "integrity": "sha512-77Rg0KQRvPJBse79SbdtdnDWR6c2XNiG7VJSZUVNuTWF37evOwJMjNg5t5e4S6HH+E70SjMmcn1FSBiklTxipQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.2.0.tgz",
+      "integrity": "sha512-o0u5df606X6xMSr2mRa/mCZ/rN9hdY9yLBgCfkniuWDY+y8zyhSYs8sFUcGTl1tqB1/HyYJxxsyBUgGXIQ+M0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-solana": "3.1.0",
-        "@wormhole-foundation/sdk-solana-core": "3.1.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-solana": "3.2.0",
+        "@wormhole-foundation/sdk-solana-core": "3.2.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-ow4wKXle2GN325bNAelkqjvn96BpLHZ6bOROOlTqkJuAFOM4XVKs6Oh/MKxU77B0qg2YnhGjRzaCRz72TbPoLA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-4V82P/kx3Vfbu9IertwtK0JKiYZPmMzV5AGwsyk8bXnXV9BRsQItsovBKqZ5/9wR6Vedb6f2raXg696wBFpZhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-solana": "3.1.0",
-        "@wormhole-foundation/sdk-solana-core": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-solana": "3.2.0",
+        "@wormhole-foundation/sdk-solana-core": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.1.0.tgz",
-      "integrity": "sha512-x6A7fMx8XB/zwIh81lVnOhGzgh6KLrXCy1P1DMzGMTdjOuun5DFEjuFQBlnOyaM/+fxDS9VoXK/rHdaik+xoXA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.2.0.tgz",
+      "integrity": "sha512-IDijoGxpq5ZhkBvXjp3PIK7l1M5dYpcp+9plq16L+kgNW9rfjy2UI67THuH0sbJMldysaz2/9kgQA8aAL7vcPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.1.0.tgz",
-      "integrity": "sha512-LlZSNoIRBOzD5ARCM8yDjdq2gHA4wHGkWpiTrWUt7Y0AMqHasXEScTQeQc4qK5n2Zo0C8QXxa7c0UHeClCcNJQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.2.0.tgz",
+      "integrity": "sha512-W8oqrXfSp8tnVT0DUXqIN6fidouQg4OjBy/W1ojN/In1Uv59U5Kn0xlmhFXkGsDSWgkEoP/HEfT2bBv4IqdnNg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-sui": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-sui": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.1.0.tgz",
-      "integrity": "sha512-KOcs2v8fZlYqozPKLxVvfFzGljefmCw/CCrjl6Zat9VdIFlPfgSnG9g7OIOpqzco9fsW4XYKoQKuOUB3VgXgMg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.2.0.tgz",
+      "integrity": "sha512-1wCb9CCBprYa0lkKwkdVi6JhjLrqp/Barnpt1+tJFE4XhmRKSdVq+0ZK10KZmpMPcGtv6baSZAmyJLFPw2eBUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-sui": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-sui": "3.2.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.1.0.tgz",
-      "integrity": "sha512-YZDjuYeLiIoorXcu4T1p2Ory7rWadk6yx9p5+RIbu6KSjVs9p82p2/imAERSZS8/Rlam3VgKHA7X1DiASQCQMA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.2.0.tgz",
+      "integrity": "sha512-zQ3VFu/xRPsX9cj88F4/rlbvMPZsfbjzzmM6doVZYJGMhFnE6AbN0XvjbIMYk377R4PjK7eisgcYp1DG2CI5Ag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.1.0",
-        "@wormhole-foundation/sdk-sui": "3.1.0",
-        "@wormhole-foundation/sdk-sui-core": "3.1.0"
+        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-sui": "3.2.0",
+        "@wormhole-foundation/sdk-sui-core": "3.2.0"
       },
       "engines": {
         "node": ">=16"
@@ -4150,14 +4150,14 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.12.tgz",
-      "integrity": "sha512-VuHbhYyhPN7XDc06Gl3jYWxMlqa1MLX5xbrmbBbzelX/+M5khxDsNBE7FvTEvAmx0RyLyDkEtRPWRfIdMCTKTw==",
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.13.tgz",
+      "integrity": "sha512-fYoorairdPgxtE7Sf1X9/6bSN9Kt2+PN8KLg3hcF8972qFnawwUgs1OLVU8efZMHwL7EBHhhKBhrsGPlOs2lZQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.7.0",
+        "@gql.tada/cli-utils": "1.7.1",
         "@gql.tada/internal": "1.0.8"
       },
       "bin": {
@@ -6165,9 +6165,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.1.0",
+    "@types/node": "^24.2.0",
     "markdown-link-check": "^3.13.7",
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.1.0",
+    "@wormhole-foundation/sdk": "3.2.0",
     "sharp": "^0.34.3",
     "swagger-markdown": "^2.3.2"
   }

--- a/scripts/src/chains/Fogo.json
+++ b/scripts/src/chains/Fogo.json
@@ -12,7 +12,7 @@
       "devnet": false
     },
     "ntt": {
-      "mainnet": true,
+      "mainnet": false,
       "testnet": true,
       "devnet": false
     }

--- a/scripts/src/chains/Fogo.json
+++ b/scripts/src/chains/Fogo.json
@@ -10,6 +10,11 @@
       "mainnet": false,
       "testnet": true,
       "devnet": false
+    },
+    "ntt": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
     }
   },
   "explorer": [

--- a/scripts/src/chains/HyperEVM.json
+++ b/scripts/src/chains/HyperEVM.json
@@ -1,5 +1,5 @@
 {
-  "title": "HyperEVM :material-information-outline:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }",
+  "title": "HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }",
   "testnet": {
     "name": "Testnet",
     "id": "998"

--- a/scripts/src/config/product-support-config.json
+++ b/scripts/src/config/product-support-config.json
@@ -5,7 +5,7 @@
 		"outputFile": "./src/generated/ntt-support.json",
 		"customChains": {
 			"Mainnet": ["Solana"],
-			"Testnet": ["Solana"]
+			"Testnet": ["Solana", "Fogo"]
 		}
 	},
 	{

--- a/scripts/src/generated/ntt-support.json
+++ b/scripts/src/generated/ntt-support.json
@@ -45,7 +45,8 @@
     "Mezo",
     "Monad",
     "PolygonSepolia",
-    "Solana"
+    "Solana",
+    "Fogo"
   ],
   "Devnet": [
     "Ethereum",


### PR DESCRIPTION
This pull request updates dependencies and configuration files to add support for the Fogo chain in testnet environments, makes a minor improvement to the HyperEVM chain description, and bumps package versions for better compatibility and features.

**Dependency updates:**

* Updated `@wormhole-foundation/sdk` dependency to version `3.2.0` and `@types/node` to `^24.2.0` in `scripts/package.json` for improved compatibility and features.

**Chain and configuration support:**

* Added `ntt` support for the Fogo chain in testnet environments in `scripts/src/chains/Fogo.json`.
* Included `Fogo` in the list of supported testnet chains for NTT in `scripts/src/config/product-support-config.json`.

**Documentation and labeling:**

* Updated the title icon for HyperEVM in `scripts/src/chains/HyperEVM.json` from `material-information-outline` to `material-alert` for clearer warning indication.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/559