### PR TITLE
Fix Aptos URL

### DIFF
--- a/scripts/src/chains/aptos.json
+++ b/scripts/src/chains/aptos.json
@@ -27,7 +27,6 @@
   ],
   "contractSource": "aptos/wormhole/sources/wormhole.move",
   "finality": {
-    "details": "https://aptos.dev/en/network/glossary#byzantine-fault-tolerance-bft",
     "finalized": 0
   },
   "devDocs": "https://aptos.dev/",


### PR DESCRIPTION
I removed the Aptos URL. This PR needs to be merged with this one:  https://github.com/wormhole-foundation/wormhole-docs/pull/566