### PR TITLE
Remove URL

### DIFF
--- a/scripts/src/chains/aptos.json
+++ b/scripts/src/chains/aptos.json
@@ -27,7 +27,6 @@
   ],
   "contractSource": "aptos/wormhole/sources/wormhole.move",
   "finality": {
-    "details": "https://aptos.dev/en/network/glossary#byzantine-fault-tolerance-bft",
     "finalized": 0
   },
   "devDocs": "https://aptos.dev/",

--- a/scripts/src/chains/aptos.json
+++ b/scripts/src/chains/aptos.json
@@ -27,6 +27,7 @@
   ],
   "contractSource": "aptos/wormhole/sources/wormhole.move",
   "finality": {
+    "details": "https://aptos.dev/network/blockchain/validator-nodes#overview",
     "finalized": 0
   },
   "devDocs": "https://aptos.dev/",


### PR DESCRIPTION
This PR removes the APTOS URL. This needs to be merged together with this one:  https://github.com/wormhole-foundation/wormhole-docs/pull/568