### PR TITLE
fix table/toc overlap issue

### DIFF
--- a/material-overrides/assets/stylesheets/wormhole.css
+++ b/material-overrides/assets/stylesheets/wormhole.css
@@ -284,7 +284,7 @@
   }
 }
 
-@media screen and (min-width: 76.25em) {
+@media screen and (min-width: 86.25em) {
   [dir="ltr"]
     .md-sidebar--secondary:not([hidden])
     ~ .md-content
@@ -302,7 +302,9 @@
     > .md-content__inner {
     margin-left: 3rem;
   }
+}
 
+@media screen and (min-width: 76.25em) {
   .md-grid {
     padding: 0 5.75em;
   }
@@ -846,6 +848,7 @@ table th:last-child {
 }
 
 /* Supported blockchains tables */
+.full-width .span-table,
 .full-width .md-typeset__scrollwrap .md-typeset__table {
   width: 100%;
 }


### PR DESCRIPTION
I came up with this elaborate plan to change the way the fixed table headers work,  but it ended up creating a worse user experience. Instead, I opted for a simpler approach: on smaller screens, we’ll use Material’s default margins (1.2 rem), and on larger screens, we'll revert to our custom margins, which are wider (3 rem).

This update also includes a quick fix to ensure that span tables with full-width classes actually render at full width.

**To check if this works**: Run this branch locally, open the Supported Networks page, and resize the screen to check whether the table of contents (on the right) overlaps with the tables.