### PR TITLE
Update sdk to the latest version

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.2.0",
+        "@wormhole-foundation/sdk": "3.3.0",
         "sharp": "^0.34.3",
-        "swagger-markdown": "^2.3.2"
+        "swagger-markdown": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "^24.2.0",
+        "@types/node": "^24.2.1",
         "markdown-link-check": "^3.13.7",
         "typescript": "^5.9.2"
       }
@@ -54,19 +54,38 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.1.1.tgz",
+      "integrity": "sha512-uGF1YGOzzD50L7HLNWclXmsEhQflw8/zZHIz0/AzkJrKL5r9PceUipZxR/cp/8veTk4TVfdDJLyIwXLjaP5ePg==",
+      "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
       "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -74,23 +93,52 @@
     "node_modules/@apidevtools/swagger-methods": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
-      "integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.0.0.tgz",
+      "integrity": "sha512-WLJIWcfOXrSKlZEM+yhA2Xzatgl488qr1FoOxixYmtWapBzwSC0gVGq4WObr4hHClMIiFFdOBdixNkvWqkWIWA==",
+      "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "ajv": "^8.6.3",
+        "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@aptos-labs/aptos-cli": {
@@ -976,9 +1024,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.2.tgz",
-      "integrity": "sha512-+pOo/v+pG5IE1X29LJsMqrFa3KRXF0hxmqn21RhPTIHyxOlSpSBmPqYoH/xR9RDr2zfVgzxH3S4tymJtVRhBqQ==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.6.tgz",
+      "integrity": "sha512-CrjgbwO9DWZR7SwNOY1IxrrynSzsAj8eqXBVZ4W4WbylRFr0ULOgYhTZ+lB4R5jf1DR1dQtPb3XFaygZk4Dgiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1099,12 +1147,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.2.tgz",
-      "integrity": "sha512-RSuaUcvws23shffGJIgEuzrEoV1LUXtf7n5VDxGc3uZadtbctGPVakQZKNxjzyzaAn97yFxTI44+y8Bu7014GA==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.6.tgz",
+      "integrity": "sha512-sHqivzqMdxvAM3QE5zmByfbwe45Mv4bb/j9eHArO79JuZLp0KZkFSGfvN8yza4ng8djMVj2mTPHqJD5xEYjNqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "^1.16.2"
+        "@injectivelabs/ts-types": "^1.16.6"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -1150,9 +1198,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.2.tgz",
-      "integrity": "sha512-tkXElQMLu42dR1TQ/xbRhMegBWiZfN12zFektBvnXzNV6VFttPp4ERDGnvFSAScblrQyKMARi3lDtw22tDwDIA==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.6.tgz",
+      "integrity": "sha512-CUHbjOSJqSwv0oSY2J9dpEgCfH+O2ckdI5xri4ILD6LreYPpqXivgWykfIGu7aKTNXiFkZ1dyfoX6zAmX62rXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -1161,16 +1209,16 @@
         "@cosmjs/stargate": "^0.33.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
         "@injectivelabs/core-proto-ts": "1.16.1",
-        "@injectivelabs/exceptions": "^1.16.2",
+        "@injectivelabs/exceptions": "^1.16.6",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.14",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "^1.16.2",
+        "@injectivelabs/networks": "^1.16.6",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "^1.16.2",
-        "@injectivelabs/utils": "^1.16.2",
+        "@injectivelabs/ts-types": "^1.16.6",
+        "@injectivelabs/utils": "^1.16.6",
         "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
@@ -1374,30 +1422,25 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.2.tgz",
-      "integrity": "sha512-/0YETj+eu3h18OjxkUtqmMCLto9VuYEpuvE2rdmz+PQNQrqOJNJyKQnOH9zYW9tGrjBCD6w+LdHkP980I1V1fg==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.6.tgz",
+      "integrity": "sha512-H2RGuD3K0mgPMQFxPW+fKuNuzOmWFbOblsgjBskKmXSpq3GTE2x2UaRwv9/Xy9KwI8J5P+K6uCGyTOiT5yfQ7w==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.2.tgz",
-      "integrity": "sha512-vPrm50x3BYLblnLJCmMVwoXEg3qvkjP53eiiCx6vG3mrqOVzf1YPJVZDBG0ZipkFhxkBjCjj/T8LdHUoVbz9bA==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.6.tgz",
+      "integrity": "sha512-IMhPw/HMaUzLpcMEn+qmeCI8MmJG4JSG6ptFT31IdltDrmLaqzSBZQqVCCKZ4ehruzwgnILXZyV6wooeEuhWmg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "^1.16.2",
-        "@injectivelabs/networks": "^1.16.2",
-        "@injectivelabs/ts-types": "^1.16.2",
+        "@injectivelabs/exceptions": "^1.16.6",
+        "@injectivelabs/networks": "^1.16.6",
+        "@injectivelabs/ts-types": "^1.16.6",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@metamask/abi-utils": {
       "version": "3.0.0",
@@ -1480,9 +1523,9 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.1.tgz",
-      "integrity": "sha512-xkQEgO/XdGz9T5vJU0iEiw8ZnuDSHWjdYA+u783wY5dt0TknYDBBcThaufhz9j+tksCxKhR5OkktE+Wz3zdYtw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.2.tgz",
+      "integrity": "sha512-HZLsKfiqbIgZvmoSPdW+AVNEzj9OYf9TV/VP9qEAIKERLS9EEeBYpz3Ju7WR6apuQvjOtPGs5yimEOuQQ7sRww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -1982,6 +2025,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -2005,9 +2054,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -2057,52 +2106,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.2.0.tgz",
-      "integrity": "sha512-4B2xyPPbpWLXGIOEwGbURqoWu31h/CXIXaN+jt11SiQx2o4eNDt64K8TAHjsQ0VfaGq7wsD5QJ5nmDpY0NEcNw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.3.0.tgz",
+      "integrity": "sha512-HoGCK+X836cKkMC6/0aZPtLUDzCmkEqFqGiAxybjX7PRob/W5SBELn32+GQyLuJEaeU9UTUto+6EIxoyfqesLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.2.0",
-        "@wormhole-foundation/sdk-algorand-core": "3.2.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.2.0",
-        "@wormhole-foundation/sdk-aptos": "3.2.0",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.2.0",
-        "@wormhole-foundation/sdk-aptos-core": "3.2.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.2.0",
-        "@wormhole-foundation/sdk-base": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.2.0",
-        "@wormhole-foundation/sdk-definitions": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
-        "@wormhole-foundation/sdk-evm-cctp": "3.2.0",
-        "@wormhole-foundation/sdk-evm-core": "3.2.0",
-        "@wormhole-foundation/sdk-evm-portico": "3.2.0",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.2.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.2.0",
-        "@wormhole-foundation/sdk-solana": "3.2.0",
-        "@wormhole-foundation/sdk-solana-cctp": "3.2.0",
-        "@wormhole-foundation/sdk-solana-core": "3.2.0",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.2.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.2.0",
-        "@wormhole-foundation/sdk-sui": "3.2.0",
-        "@wormhole-foundation/sdk-sui-cctp": "3.2.0",
-        "@wormhole-foundation/sdk-sui-core": "3.2.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.2.0"
+        "@wormhole-foundation/sdk-algorand": "3.3.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.3.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.3.0",
+        "@wormhole-foundation/sdk-aptos": "3.3.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.3.0",
+        "@wormhole-foundation/sdk-aptos-core": "3.3.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.3.0",
+        "@wormhole-foundation/sdk-base": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.3.0",
+        "@wormhole-foundation/sdk-definitions": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
+        "@wormhole-foundation/sdk-evm-cctp": "3.3.0",
+        "@wormhole-foundation/sdk-evm-core": "3.3.0",
+        "@wormhole-foundation/sdk-evm-portico": "3.3.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.3.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.3.0",
+        "@wormhole-foundation/sdk-solana": "3.3.0",
+        "@wormhole-foundation/sdk-solana-cctp": "3.3.0",
+        "@wormhole-foundation/sdk-solana-core": "3.3.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.3.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.3.0",
+        "@wormhole-foundation/sdk-sui": "3.3.0",
+        "@wormhole-foundation/sdk-sui-cctp": "3.3.0",
+        "@wormhole-foundation/sdk-sui-core": "3.3.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.2.0.tgz",
-      "integrity": "sha512-L8PMH6VnroNFLj637x//Z8U4f5U+4D3lXoWm28kMRcanJa8fFcOu6gVjjIAsIO9avf9AQTXqvmUR9lUNvDh+sg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.3.0.tgz",
+      "integrity": "sha512-PU61mV644nDmRH2kuxoPw8bCjp9/lOPukIv55935PWnSeuthHPPhJusCgPKaVDX3Rs65she1Jpag3lI4GgupZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2110,89 +2159,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.2.0.tgz",
-      "integrity": "sha512-CAGLZddbKjx2fa0H6ols3oIHmNq5WqmNG1N6NbsFaiNaLMNHeD0gMUTXrmSesN43gO9z1RleBH9otmrw2k7H5Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.3.0.tgz",
+      "integrity": "sha512-iIGoyX6G38ue8IiSdvJ5EyMjt2xJ6s/uDb7FPVbGcsCGnFQTmbbTgU9t3EEBEk9Iqsg9peoX67xNRWg42KmRKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-algorand": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-Q2RM/Mzp5VmFdo734HupAGLud11Z0h6cMibuAqZWCfPfe5GHsvGEqyPCarzPWBKvoas6SqPIRZ+VY8fMoyBPCw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-5v0/+bNk2pLW8KEHNYSHVoRBEhlrxY64drDqSHJCSugDPTfos3HYKKhYy4hqDGtyCIPyEQ2KOVfhQBUH3WAQXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.2.0",
-        "@wormhole-foundation/sdk-algorand-core": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-algorand": "3.3.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.2.0.tgz",
-      "integrity": "sha512-norK+UcreLCKWMchGLF6gfRGbdWWa2x+yEfFIcO1/3oko68UYefwJhoP/mptMX1dqgoX2wTqMu9Hwt3zwMmO3Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.3.0.tgz",
+      "integrity": "sha512-JYE3I4Ky/R0j7xYt4RUhLhgq+PhVcp+5LTQyCzibfokr/wa44kaaoIso46zHlkgpe/jppsJNSQYo5nhRnDw6dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.2.0.tgz",
-      "integrity": "sha512-U0Jsca97ZESWMPAoBnIMh1MCvn9j/1Yy+obV2/WPANRlFpF6O8VeTiyIRv0vCg14/WjBV5zqtBsNzxda6Zc3UQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.3.0.tgz",
+      "integrity": "sha512-kt5Nbh1O3evKjU7tbZ4y3uUsQnu8LTkdFBpO6CPPBx01/YOBCIQTMLHPFpgqJFjgjolqWOhFNPI4JICaU2zt5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-aptos": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.2.0.tgz",
-      "integrity": "sha512-9jJkDqAGWdRWS8mzc2k/vUW3McZ+Yqt3wtzX8CuqqEv8QGidli4Rm00nzvif6O0dIE+HmmGwpWmJlZ7jJ4sSZA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.3.0.tgz",
+      "integrity": "sha512-7c58Ojwxs5iU84Qo3FOUN3UA59imILLe50Fdi8C30wiJpfUj/bCwqKkJSGuJjCNf9f5zH7gPOzfqTeS/b7kQug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-aptos": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-3tZsdY4IvEYnce579MzCqK1XoqJqA5D7PnN/XV/7AA0VCJq7hjWmZksfkR4DRCsUKr2sl/T6+wYOof0AtQV1sQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-7N40R++7y+rsJDcWcnnunlD8HppCPzib+3DUVaCYGcxVa3MlMWJTKM7iqE1P3AZN7OKIPwxr8Jcf4CQRJUCnFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.2.0",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-aptos": "3.3.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.2.0.tgz",
-      "integrity": "sha512-Ss90qA3Da48Lu0VCrXA4di3r9IT/a6w6mUBU8dLYEZcCsllWP864Ru/no22C57Kash2uo4KB3TgPLnEi5iCqbw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.3.0.tgz",
+      "integrity": "sha512-9nbM5snmZcqNwRkEUF5P56/Y+aREzqhY/BCr3T248qK5WEHLxirohicF//JdWFXg6iVWbwhoziXBiY5ZhzCQJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2200,13 +2249,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.2.0.tgz",
-      "integrity": "sha512-vc7RKLiO715qMoEkHhFVfuVg2AmUBCUj8gnw84PwOn6PYZKxQpYvZfgKKztvL1GDfaO+R3+nT8WxfSemLK0R3w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.3.0.tgz",
+      "integrity": "sha512-UqRX6P9jXwc0Ap/6hCxylewYQeO+yo4h4cEZSm7Zivwzu6Z3+JuNNIi8Hor2h85ow4PCRZTeO/nq7SaWjyDJKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.2.0",
-        "@wormhole-foundation/sdk-definitions": "3.2.0",
+        "@wormhole-foundation/sdk-base": "3.3.0",
+        "@wormhole-foundation/sdk-definitions": "3.3.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2214,16 +2263,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.2.0.tgz",
-      "integrity": "sha512-uH76AyBF00VObYoOcdYBY4fHGI5WXzlGTrAuM8IV2oX9oYjA9MrCyzP4vVfeleWJRPB8ZY+7cOz6keS/ngMD8A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.3.0.tgz",
+      "integrity": "sha512-5IDca7YCEDD4lqQhLFGKcClgDvKrvFdjvE6fcxa/wg8IlBCZ42V7PTY8wZcgAXjRhsUUeYiDt3ol0QTn3KsCaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2231,33 +2280,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.2.0.tgz",
-      "integrity": "sha512-9Rko/UcSIpIyG4blx85zQf8OMFXBrx9qcqKGF9Q0voQJED3ldMtQtXHkWF/8pg3sjTuzmdLltxFBwy3uHWNN1g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.3.0.tgz",
+      "integrity": "sha512-2V6tCg2IIdxuonw2of7eEVNpv/SS1kMPslFoe1kgDzXPUGigcKJC5b2TaP8yw2bOkuM26v5F5xNjigsgblFbwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.2.0.tgz",
-      "integrity": "sha512-6u+HMzv8nck8W++jO0qgc60ILODTXmHCIGq/dwLWyov50gZ23LXG9Uz1ZwFVy1Ja7wm2u6hInRFoXXlF1tSW/w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.3.0.tgz",
+      "integrity": "sha512-OMfQSqkgOuyQX7tQVP5iaRn3dPf0Pm9e/DebiFAMKyE9EzqKur+6OOwWDtKcqP7kAmhHzEQCp05uW0a6CcF2GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.3.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2265,37 +2314,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-KiUnLcoxv9yZ6Eh5c/X+iK31OiiMAME+Cr47gyntbs5pLDuGJIVQRLVXjqTer0KleIobunReLXaIVsyrX9tchQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-x3GbD/S49kejaIQFsaX7ly32OvHoBHapfGRa51HzHUu9RuK2OFOSXDiRPih8qAyWD8vP3ATywPOiqqD+cbeNuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-cosmwasm": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.2.0.tgz",
-      "integrity": "sha512-6HPDxFM6dmtVqs6JDETIXLsm0evgRhOOGAoFI48BgJJiYJwDZApfJHOo02dN0wPVYiWQdNDRCevS/sGSM9dSVA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.3.0.tgz",
+      "integrity": "sha512-ug8L0X3TWk6M6IMtDNOOYGrEwKGGmVstoAiSQMj0S8mp19Wfw4V7ZlkrtsWnQI7aloeYT1bkmtnjztyy5zD8Fw==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.2.0"
+        "@wormhole-foundation/sdk-base": "3.3.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.2.0.tgz",
-      "integrity": "sha512-HtNSPIQDV37VJFSi82ndy4KQ/ELmp7RHrgX/HTzOQ+tKoRjTvdwSrjZRMsVEPJTA+FNbS+WXpQ9Aeotdg7eMHg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.3.0.tgz",
+      "integrity": "sha512-2gu9GKfKTDVAIQRqX7vw5msTFPTpqMipCJ+VOqmtvrZoK6LPzfKRjDSA10hAr9ljbNG2Txixi6LtbDQjWjDV2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2303,14 +2352,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.2.0.tgz",
-      "integrity": "sha512-OfuD59KrpKpe4keD/4xD0CKo5938efL6BotsfuJf7LnWiB/sL9HHjuBQebH3X7ymSHGeMuUm0Ah/8TPF3jRa7Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.3.0.tgz",
+      "integrity": "sha512-ecLpUWYSfzDUMr6OdQpxlsxU0S+SCEWJ+RBJgDVs9tu9Ur1GEDwajSZC3Rm4kMpd/riFgDQYNUidJuJOoO7jrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
-        "@wormhole-foundation/sdk-evm-core": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
+        "@wormhole-foundation/sdk-evm-core": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2318,13 +2367,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.2.0.tgz",
-      "integrity": "sha512-5GRyC+oHY4Am7jnw+KFrWNWSxE/tO8VzIH5qBeHLhnxevpx7a87SC8FLGn6m88kT+CAQohqmnlwwtsFkQsBtZw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.3.0.tgz",
+      "integrity": "sha512-mTMa3e8ffufDPIP8DNzLgR8V6yDxrF07uv4AuBobSpu58xSl/GnCe4nSWrOQlu6RlIjQp4i0DngrL+Hb434clA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2332,15 +2381,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.2.0.tgz",
-      "integrity": "sha512-W/Y5k82B6G4UBKLArK8MhmfLZ1h1bOioRbqi8MYcYoW+Gte5jBZ3rrKHHAQTXe2VO2cg/4kJS9HCb7GLM3vWbg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.3.0.tgz",
+      "integrity": "sha512-T8oS/cLMIODgAC9LzVH6SRR4KK2AISxSdg1iVaxpFzdyvbosXG2iwDwH5HQgOqmudWTXMSceDyZB0wel1vu4Mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
-        "@wormhole-foundation/sdk-evm-core": "3.2.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
+        "@wormhole-foundation/sdk-evm-core": "3.3.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2348,14 +2397,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.2.0.tgz",
-      "integrity": "sha512-JY1Ord+Rd6xkY03cG/6purLE5qIG3jy8qwwjmq6oQl2aDcKHx34mO5lsAoon3B7MG3uWXBsRDaspsMR25//pPQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.3.0.tgz",
+      "integrity": "sha512-1qyQzXL7LuBmUAL+0L2pULlIAnIEANg/b1CFbBTAbBFQCbpMLUDe9SKNZFknLnvGZqjQ8fOumFCwtflSQRhPBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
-        "@wormhole-foundation/sdk-evm-core": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
+        "@wormhole-foundation/sdk-evm-core": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2363,14 +2412,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-AYTShYueKWl01ijL99o9+LHbqAFI+h8v1jS7x5wXC2TftbpHfWKmNFiginWCZOeCKmR3HXirLZFkeJN702ANzg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-SfuJkjFKWLKsSc/kiYiuD3fEu+dwtCyaNrAnG4oZcKNc4IC8qu0HCwXk/S8sTLLKjK1rNS+ZZXg1AKfhb5lZkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-evm": "3.2.0",
-        "@wormhole-foundation/sdk-evm-core": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-evm": "3.3.0",
+        "@wormhole-foundation/sdk-evm-core": "3.3.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2378,16 +2427,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.2.0.tgz",
-      "integrity": "sha512-YzPYgDyzlQ+3/wLQq1kfo6F9kfLTp9tY2bw2QXVP6EdibY0vLQuAfpfuboXGGKNpZkdV/ACpe1MJM+MxXIDu5w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.3.0.tgz",
+      "integrity": "sha512-lSta1SeBFEydQH/8pCaBa6UaDg5sDvX5YvYC+nksXQq6FIRAbirW6ccIWF28xKFXFr5yxOjvtyketC/tKEic5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
+        "@wormhole-foundation/sdk-connect": "3.3.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2395,123 +2444,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.2.0.tgz",
-      "integrity": "sha512-qc59CHWu+ZGpG3iAyS2dwHqnySKuclI952sihAbQ+13rcqAfCnYKXl+dPnOD+53RMi2/F4MgHSyMPbjwDwKf+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.3.0.tgz",
+      "integrity": "sha512-p0Q6cGn/JYUol4L7Tb3tXW+yGyW19Tg+cVhHJD9gFV+uNgELOOATKhCwXO9bVJSTxuhAx8zjIrHcLQi9ZEWxHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-solana": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-solana": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.2.0.tgz",
-      "integrity": "sha512-3Q1t8KmWhD5+5vvlLcLtUHyPWmoCq2ytfEa4ZctDSIG+oXEj20mVEGvolz2FJkHFi0cgB0/z1U0tcVWT7gPjRA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.3.0.tgz",
+      "integrity": "sha512-DNGmXeRa9sIdMH1ELf/oP0GrUC1I7XsIeG3V4KoxTj1te9YpeqCjhJVCuY48GYs12sa4oozudjfyyKG7MQUxCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-solana": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-solana": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.2.0.tgz",
-      "integrity": "sha512-o0u5df606X6xMSr2mRa/mCZ/rN9hdY9yLBgCfkniuWDY+y8zyhSYs8sFUcGTl1tqB1/HyYJxxsyBUgGXIQ+M0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.3.0.tgz",
+      "integrity": "sha512-QnRWqlx9XmARsRX/O/5/YYlMbHoWI1ZcPhurpZRmd5wVObZqPajx+0RWH/6cx3BDqRVrpUQ3rU8yTGcexAcjFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-solana": "3.2.0",
-        "@wormhole-foundation/sdk-solana-core": "3.2.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-solana": "3.3.0",
+        "@wormhole-foundation/sdk-solana-core": "3.3.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-4V82P/kx3Vfbu9IertwtK0JKiYZPmMzV5AGwsyk8bXnXV9BRsQItsovBKqZ5/9wR6Vedb6f2raXg696wBFpZhQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-Ow9XsRt3u1bsGHPuGkoUXOiRPWdk+SSvfsD/9iuPH4DCJTT8V/ndmDqaK6sF0I4vj1APxn74V65Oo2nXodxLzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-solana": "3.2.0",
-        "@wormhole-foundation/sdk-solana-core": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-solana": "3.3.0",
+        "@wormhole-foundation/sdk-solana-core": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.2.0.tgz",
-      "integrity": "sha512-IDijoGxpq5ZhkBvXjp3PIK7l1M5dYpcp+9plq16L+kgNW9rfjy2UI67THuH0sbJMldysaz2/9kgQA8aAL7vcPw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.3.0.tgz",
+      "integrity": "sha512-FKGfs60IAMEet9ZkEI1CToVZLss8EOsvByaz4laPu3ytg/As649Zc+8OqBrOd3bE0kmBbh9n/eIMajXOexYRXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.2.0.tgz",
-      "integrity": "sha512-W8oqrXfSp8tnVT0DUXqIN6fidouQg4OjBy/W1ojN/In1Uv59U5Kn0xlmhFXkGsDSWgkEoP/HEfT2bBv4IqdnNg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.3.0.tgz",
+      "integrity": "sha512-sp0dlWvGD08pzAxYQSDrf3mi5DOp206+RBMxqvmXTjhj9YvQ0vBF4CSMcHHI4PJKn7QGSFlbPcAr4CjeMOUJDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-sui": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-sui": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.2.0.tgz",
-      "integrity": "sha512-1wCb9CCBprYa0lkKwkdVi6JhjLrqp/Barnpt1+tJFE4XhmRKSdVq+0ZK10KZmpMPcGtv6baSZAmyJLFPw2eBUQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.3.0.tgz",
+      "integrity": "sha512-YIusqBCD4gfqx0CTV9dr/VxqhAdyQO9B5cKut8L8XfvyC6oT3fftggUaWd8plAV+zH3clA5vZ+Kau1yhTRsJcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-sui": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-sui": "3.3.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.2.0.tgz",
-      "integrity": "sha512-zQ3VFu/xRPsX9cj88F4/rlbvMPZsfbjzzmM6doVZYJGMhFnE6AbN0XvjbIMYk377R4PjK7eisgcYp1DG2CI5Ag==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.3.0.tgz",
+      "integrity": "sha512-UsAz8225wTs4wG6sr3JLlq2nqVREOtR/ve5s6pyGNaJjACLOviGSB4sCyDGC1+YD/C+s+a5LUqOOqdAubl/yZw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.2.0",
-        "@wormhole-foundation/sdk-sui": "3.2.0",
-        "@wormhole-foundation/sdk-sui-core": "3.2.0"
+        "@wormhole-foundation/sdk-connect": "3.3.0",
+        "@wormhole-foundation/sdk-sui": "3.3.0",
+        "@wormhole-foundation/sdk-sui-core": "3.3.0"
       },
       "engines": {
         "node": ">=16"
@@ -2594,14 +2643,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2612,6 +2662,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
       },
@@ -2782,9 +2833,9 @@
       }
     },
     "node_modules/binary-layout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.3.0.tgz",
-      "integrity": "sha512-jDJ6rLgjjQ9q8NP5eIumdvsegbbMsNplJ7GHMuVnMWi0Qw59o8kIOw+ew4fLAryPL3LgIp5KrjfdAMoSpmpO8w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.3.1.tgz",
+      "integrity": "sha512-kI8sWK05lJ1Qvkd6lC3slsD1bc4mJTTktyie3SkZE1BA8NCczpO9aynCm8HKrl/tpw2usAxHUiCDbHBZpo8/3g==",
       "license": "Apache-2.0"
     },
     "node_modules/bindings": {
@@ -3023,7 +3074,8 @@
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -3666,6 +3718,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3920,13 +3973,30 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -4607,9 +4677,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-sha256": {
@@ -4640,6 +4710,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4652,6 +4723,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -4682,7 +4754,8 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -4764,15 +4837,6 @@
         "proxy-agent": "^6.4.0"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4838,34 +4902,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/markdown-link-check": {
       "version": "3.13.7",
       "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.13.7.tgz",
@@ -4908,52 +4944,6 @@
         "marked": "^12.0.1"
       }
     },
-    "node_modules/markdownlint": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.32.1.tgz",
-      "integrity": "sha512-3sx9xpi4xlHlokGyHO9k0g3gJbNY4DI6oNEeEYq5gQ4W7UkiJ90VDAnuDl2U+yyXOUa6BX+0gf69ZlTUGIBp6A==",
-      "license": "MIT",
-      "dependencies": {
-        "markdown-it": "13.0.2",
-        "markdownlint-micromark": "0.1.7"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/DavidAnson"
-      }
-    },
-    "node_modules/markdownlint-micromark": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
-      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/markdownlint-rule-helpers": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.22.0.tgz",
-      "integrity": "sha512-fYZ68UFpMYXeaQ0BC7xkij1iJd57tqfO5koPc92kDegZDoHq692UqSwxpfcf4i+SnL134sLIlBHrOxXnLmfvsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "markdownlint-micromark": "0.1.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/markdownlint-rule-helpers/node_modules/markdownlint-micromark": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.2.tgz",
-      "integrity": "sha512-jRxlQg8KpOfM2IbCL9RXM8ZiYWz2rv6DlZAnGv8ASJQpUh6byTBnEsbuMZ6T2/uIgntyf7SKg/mEaEBo1164fQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/marked": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
@@ -4986,12 +4976,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "license": "MIT"
     },
     "node_modules/micro-ftch": {
       "version": "0.3.1",
@@ -5487,14 +5471,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -5576,6 +5552,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5985,7 +5962,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
@@ -6030,15 +6008,14 @@
       }
     },
     "node_modules/swagger-markdown": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/swagger-markdown/-/swagger-markdown-2.3.2.tgz",
-      "integrity": "sha512-VuRUMi6Nk6/nYu7j8eZcFHOIZ1UKhc1ZzryAScBGeHpxWqoooy6dAg7BofbLrmThhQBemJxdKFK/USmRgdNwAQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-markdown/-/swagger-markdown-3.0.0.tgz",
+      "integrity": "sha512-5pdQn9H2hSh7r+V3Y2pqp9DcZh9J2NYGUg6uO1qbcS+a8P16ew1YgQ5Xnbe47FyQSOa4z4LVulfIjAUWrzNypA==",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/swagger-parser": "^10.1.0",
+        "@apidevtools/json-schema-ref-parser": "^14.1.1",
+        "@apidevtools/swagger-parser": "^12.0.0",
         "argparse": "2.0.1",
-        "markdownlint": "^0.32.0",
-        "markdownlint-rule-helpers": "^0.22.0",
         "openapi-types": "^12.1.3"
       },
       "bin": {
@@ -6148,12 +6125,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
@@ -6169,14 +6140,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,13 +13,13 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.2.0",
+    "@types/node": "^24.2.1",
     "markdown-link-check": "^3.13.7",
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.2.0",
+    "@wormhole-foundation/sdk": "3.3.0",
     "sharp": "^0.34.3",
-    "swagger-markdown": "^2.3.2"
+    "swagger-markdown": "^3.0.0"
   }
 }


### PR DESCRIPTION
This pull request updates several dependencies in the `scripts/package.json` file to their latest versions. These changes help ensure compatibility, security, and access to new features.

Dependency updates:

* Upgraded `@wormhole-foundation/sdk` from version 3.2.0 to 3.3.0 for improved features and bug fixes.
* Updated `swagger-markdown` from version 2.3.2 to 3.0.0 to include breaking changes and enhancements.
* Bumped `@types/node` from 24.2.0 to 24.2.1 for the latest type definitions.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/576