### PR TITLE
switch margin so it's on the wrapper instead of the table

### DIFF
--- a/material-overrides/assets/stylesheets/spantable-neoteroi.css
+++ b/material-overrides/assets/stylesheets/spantable-neoteroi.css
@@ -8,12 +8,12 @@
 
 /** Span Table CSS **/
 .span-table-wrapper {
-  overflow-x: scroll;
+  overflow-x: auto;
+  margin-bottom: 1rem;
 }
 
 .span-table-wrapper table {
   border-collapse: separate;
-  margin-bottom: 2rem;
   border-radius: var(--border-radius);
 }
 


### PR DESCRIPTION
This PR just modifies the scrollbar so it actually looks like it's for the table instead of floating below the table

Before:
<img width="311" height="312" alt="Screenshot 2025-08-22 at 10 21 02 AM" src="https://github.com/user-attachments/assets/b5782e60-ac79-401b-8c7e-47ad5f114090" />

After:
<img width="307" height="315" alt="Screenshot 2025-08-22 at 10 21 34 AM" src="https://github.com/user-attachments/assets/e0eeac6c-c7d4-4726-8ca1-3458fe3449d6" />
