### PR TITLE
Update submodule to e7e010c

### DIFF
--- a/material-overrides/assets/stylesheets/spantable-neoteroi.css
+++ b/material-overrides/assets/stylesheets/spantable-neoteroi.css
@@ -8,12 +8,12 @@
 
 /** Span Table CSS **/
 .span-table-wrapper {
-  overflow-x: scroll;
+  overflow-x: auto;
+  margin-bottom: 1rem;
 }
 
 .span-table-wrapper table {
   border-collapse: separate;
-  margin-bottom: 2rem;
   border-radius: var(--border-radius);
 }
 


### PR DESCRIPTION
`wormholde-docs` PRs:
- https://github.com/wormhole-foundation/wormhole-docs/pull/594
- https://github.com/wormhole-foundation/wormhole-docs/pull/595
- https://github.com/wormhole-foundation/wormhole-docs/pull/596

`mkdocs` PRs:
- https://github.com/papermoonio/wormhole-mkdocs/pull/339

This pull request includes minor updates to both the CSS styling for span tables and the documentation submodule reference.

Styling improvements:

* Changed the horizontal overflow behavior of `.span-table-wrapper` from `scroll` to `auto` and added a bottom margin for improved layout and usability. (`material-overrides/assets/stylesheets/spantable-neoteroi.css`)

Documentation update:

* Updated the `wormhole-docs` submodule to point to a newer commit, ensuring the documentation is up to date. (`wormhole-docs`)