### PR TITLE
Update the SDK to the latest version

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.4.3",
+        "@wormhole-foundation/sdk": "3.4.4",
         "sharp": "^0.34.3",
         "swagger-markdown": "^3.0.0"
       },
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.4.2",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.4.2.tgz",
-      "integrity": "sha512-TygCcGmUbhmpxjYMm+mx68kRiJ80jYV54/Aa8gUFBv4cTX7ulX2XZKr8CJoJAw3K3FN5ZvCRmU0IzWZFaonwhA==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.5.0.tgz",
+      "integrity": "sha512-fgPTBWyFhGp8VZ5HsWniY5qZIb9DfusRB8ssw8unGIomICCK+cnEcV2xajhpPJ6QPH62y1KyVHF+VbXKrgilLA==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -1503,8 +1503,9 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
+        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash.memoize": "^4.1.2",
+        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -1524,9 +1525,9 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.37.4",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.4.tgz",
-      "integrity": "sha512-3dKddNEF7XTfPnYIfVyHHTX+9fraQrKFxiBJ8nveISqo4skyClH/nDyS8Nkh7coknbWghuSSsD82liCOZX2uLw==",
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.5.tgz",
+      "integrity": "sha512-kAKizRUdhC/gwQ7UkubbmwTno5UoA1a7Ps8R6GlPVWpCfpVM2HytmwFDOKVMA+51Qji4BaNxyq25SRpJw76fPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -2042,6 +2043,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -2107,52 +2114,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.3.tgz",
-      "integrity": "sha512-ztSOFVuTW7LPTPaOSf86WupV5JvG7XMgJ/somU/rQz6aP9JPrYqe8Ci6LXe35SdawlN1j5XVEbe9nof+Kc6Glw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.4.tgz",
+      "integrity": "sha512-8LgJsvR2AGzRYywjGvfAMBUBwOiJ7CQhIcjNpcvAOr/pTbpl/zlpI//Newi1LMrZ5rQNJMcHzlGwHGAWPjoMYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.3",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.3",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.3",
-        "@wormhole-foundation/sdk-aptos": "3.4.3",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.4.3",
-        "@wormhole-foundation/sdk-aptos-core": "3.4.3",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.3",
-        "@wormhole-foundation/sdk-base": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.3",
-        "@wormhole-foundation/sdk-definitions": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
-        "@wormhole-foundation/sdk-evm-cctp": "3.4.3",
-        "@wormhole-foundation/sdk-evm-core": "3.4.3",
-        "@wormhole-foundation/sdk-evm-portico": "3.4.3",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.4.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.3",
-        "@wormhole-foundation/sdk-solana": "3.4.3",
-        "@wormhole-foundation/sdk-solana-cctp": "3.4.3",
-        "@wormhole-foundation/sdk-solana-core": "3.4.3",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.4.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.3",
-        "@wormhole-foundation/sdk-sui": "3.4.3",
-        "@wormhole-foundation/sdk-sui-cctp": "3.4.3",
-        "@wormhole-foundation/sdk-sui-core": "3.4.3",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.3"
+        "@wormhole-foundation/sdk-algorand": "3.4.4",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.4",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-aptos": "3.4.4",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.4.4",
+        "@wormhole-foundation/sdk-aptos-core": "3.4.4",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-base": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-definitions": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-evm-cctp": "3.4.4",
+        "@wormhole-foundation/sdk-evm-core": "3.4.4",
+        "@wormhole-foundation/sdk-evm-portico": "3.4.4",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.4.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-solana": "3.4.4",
+        "@wormhole-foundation/sdk-solana-cctp": "3.4.4",
+        "@wormhole-foundation/sdk-solana-core": "3.4.4",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.4.4",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-sui": "3.4.4",
+        "@wormhole-foundation/sdk-sui-cctp": "3.4.4",
+        "@wormhole-foundation/sdk-sui-core": "3.4.4",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.3.tgz",
-      "integrity": "sha512-oE9orhVNBWWxJbI9bulNpSmXTdYpYP0J0NeQlT3GMVe7taQj2hThixVRAtQTyhSn2CA4VImnJ6Wc9Fm9JiTGRw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.4.tgz",
+      "integrity": "sha512-inwusqDtlHQ6DME5Rtn9vAyf0Sa48boQXc7Ci/ta1yAVrV00xkzvoz64Fy6lg3v54mFcdV04/d60Z/5r+A9JTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2160,89 +2167,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.3.tgz",
-      "integrity": "sha512-rdEiGPkEmnZE++PkioSVagPTQVKrr2ml5sHW6pGxzAdwSSpBT2GVsl3tfAUYDVwiIJjqck8po3DAQEC99iljPg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.4.tgz",
+      "integrity": "sha512-EeHlYy0TBFRjuzQKPMiWpuJDcsdjKHTvvTqkzysAWHhS4/zMou60g9BbSsMLcSJKPesJZGLPmDd2D7X4PAsN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-algorand": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-gWJfcoFLlpfD4EpWNNZBlkvCoROa/0VsvPFygHKeOse0k47KvHQLOBrTII2AKAnFZQ3IyP5J9LNHA2feENTAzw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-1OMkbNpBOH69m3hCjaHq3xiTSIUyU1LXpdJfSaSkbLnEqy5t2Ee8tHwyjf5vH6ti/0d26OST0lhGPkUl+5mlVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.3",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-algorand": "3.4.4",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.3.tgz",
-      "integrity": "sha512-nRypYpStSwVbfH4K5hm+35lUN82A3xjokYkuTBmxJbFKiM8hDR2vnYitOOYj6i01EIOZZ+tDcl9UpgUNcOkSDw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.4.tgz",
+      "integrity": "sha512-tGOML0ftOMpxI9oOb5/FYEjzhUofBxBrEKAE/hh5E/4eSIg9mCSp+wCQj0BDqlt6sRy36RwhJD3hvbYuwGC0ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.3.tgz",
-      "integrity": "sha512-MrehMA4HMgaS+VQi4VHdzO3a7VoA6PU2Yr4aPxcS9GulKYt0eMRSbajX+j2SMWJNSJHsGhLIoYz/DmXg1BMtVw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.4.tgz",
+      "integrity": "sha512-gGRgszsacPRTIXyA/CsMLgd3eJr3QnXwfFqpu93iO5NtuCkdddWpwyb2ukilBbd9dhJMMfB2iKhMCbV83G4Zfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-aptos": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.3.tgz",
-      "integrity": "sha512-Sp8S8NzFSXPiuOM0k0T3xJpogpFSDQoVCwvMrJV8kgf3hX44Piu5we0gYawHJdUIvrw8cTi5MVMPC/KGkh980Q==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.4.tgz",
+      "integrity": "sha512-2ePZzHuLiwqm3+egGM9YBixUy+PXHuwOZI5yZJfwPbrN4FALkC5EX9iKa+donsGlmT5I50TQHGSgXAESuTOVQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-aptos": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-dYpX3KyetQfbI9Ajdn3ZZgma65oCM7mphzd9xT8eXXY8kRIfrEHD6PIctwKjwGZ7sA+mcOmx6rh9Jh83xwphkg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-O6TO0Z/aKBt3qc+HeDqMnH2xnX8SaqqE73T1ExtLS2qEdl0xLIAnQN0QR/HqoiUqxaTXecJNjusuQyDQA9McVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.3",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-aptos": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.3.tgz",
-      "integrity": "sha512-3ZExDfBDgLonZhIZRNU8EKY6WN4JgCM53fFzaLaP/erKR6WwWfuN47TpVXaI+lzjMa34zb8QW2uP2oFNYE1zlQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.4.tgz",
+      "integrity": "sha512-V5lZNBPr27wmbDUI1+cquaMGgxPllcMwnha+lFT3+RTxWY8+i/9xnOTjkcNknba3pRlOEq5u/c+GbX7JO3vsPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2250,13 +2257,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.3.tgz",
-      "integrity": "sha512-IFOc5IeoUtxHIPrck0INVOKXAp75WTnANkjgEnghcZsH8H62+uY3skYd/2zcF7nUVXIsEgTenyNi66D9Crl+xg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.4.tgz",
+      "integrity": "sha512-01PNBa7yM9aXnpG72OC4F2sriORN+kmUIQMjT9zCtslDPfliysMEJ3DHFIyBK6uGyek+SPpeFzLZcFUAFlmbIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.4.3",
-        "@wormhole-foundation/sdk-definitions": "3.4.3",
+        "@wormhole-foundation/sdk-base": "3.4.4",
+        "@wormhole-foundation/sdk-definitions": "3.4.4",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2264,16 +2271,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.3.tgz",
-      "integrity": "sha512-cNq6Ou0uUD9rFm8u/ozB/KobjfNkw2mdibMJuZ6egQnIX5qt5JlO15DSGfkfGXgZShbO3WL4uZX8dFvxPn0wEw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.4.tgz",
+      "integrity": "sha512-VgDtmrjWLOrMsAF+auBVlMCCGgLbaGoOxdyrVwRgg/ofas1cPbOy4tU6tTLayefGd6dKUlX5CgECT1v3Iyez2Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2281,33 +2288,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.3.tgz",
-      "integrity": "sha512-R/KzqQwpEfvAwU40l4T0FRwtOn3jwXcWx3l3bvM+ekrnE6+bAl5wOaQxfbFEgApWJtzX6F56KRn6wbk8VB6sQA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.4.tgz",
+      "integrity": "sha512-X3hfbBKxvLXpG/tXZj9CoW7EJq6Him69y9tfxSj7nMMg+uQMdzLrMXqxo+BH4zImoWuTq6iFNNtmCoLYNklgiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.3.tgz",
-      "integrity": "sha512-lGr/oEcr8ZaTxu0bSQXMjPJaOzZZ/5zrqQH3zCKb4cpwzrvfRrPCTN9+neWT7JQ9w9ekatcE583o57jBR+bnvQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.4.tgz",
+      "integrity": "sha512-NSq+tO3tiCZVUfmOunofUumYkPdTIgyog297ZUfCUFY10ViuC9ITIIAFLsMMZWo9rOolaBRBFXFKxlPGPCa+Nw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.4",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2315,37 +2322,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-MYGYUvGd88T+FKrYw54JAA5jKVypeezuJtmGAqamyIz01fWGcmE02aWPwqPTZ9kKnAgptqWu2cUWbUUfCYfHDg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-6G8Dmrn/bOm+e1rLdQfF5RCXmiTsbw5LUMLFbAl8ycDFfoDu0IRhVfVuTT+HPHSsM4ZTbJMyTU8VqZO/E9pxpw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.3.tgz",
-      "integrity": "sha512-JtYiPKL2m7FRA+C5D+wrggV6ZE0/ABzDLFiLVx69Yn8XMvqSSJi3FAMrjAuIRfQsL0in8y2dxFHMTHr39rvasQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.4.tgz",
+      "integrity": "sha512-YWAp3fWRrBIIMcuaB5xqFiAjbMGIrALF+Yw3+tDD6sYumZfihEe/Qh3USjsngyFSSO0DO68ul8mG3CQ+erhssA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.4.3"
+        "@wormhole-foundation/sdk-base": "3.4.4"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.3.tgz",
-      "integrity": "sha512-8q9r2kq2GGjipKYNXpIiY+lQ0ESP5N2+eNIjC/a86yHaLKgT+uWPUNSc26OtIVIEhv89FbuzuG3ubby8Vo/axw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.4.tgz",
+      "integrity": "sha512-0xNrN5RGL1KA0L19hWm4sax4U1uQKcl62BZJVoG/tj3yNczMajTOe8zfnDNiyW8HTr3/adIl6+bvcyxoJfqGdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2353,14 +2360,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.3.tgz",
-      "integrity": "sha512-+IwFOl7yDgFxpXq3BZmIgI18jNjbzZkSPEuWk+BUfG+O8V7dQmXC/UcJXWYjGRU4CatMfgjvxCg8AM4nZ63OQQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.4.tgz",
+      "integrity": "sha512-T/Bua4MGOLPZG+HsoNbgqsntpw1QRUuwX4stS4kHmQeNWqz3Mh+vARpmv9ZWhkMZjfDMJGeI4xf7JC782es2kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
-        "@wormhole-foundation/sdk-evm-core": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-evm-core": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2368,13 +2375,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.3.tgz",
-      "integrity": "sha512-RSuxeTfFnVmEVAQCMgTdNolrSoDHmnP4pmWfI+Kl8WccJcHA4g21c2jPKdH7VT9hgTXFE8lc/JMPU5liGhF8Sw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.4.tgz",
+      "integrity": "sha512-4uZuXWDET5b7bqbs4h09Fw8TgJCmLH/HYIpYy0qgcEvnJwsbw+ZtAvPkAQnSJaaANB3IHj+oZvyDci9Cz11lHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2382,15 +2389,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.3.tgz",
-      "integrity": "sha512-vcNqMDNNjPV0E7iDz9UDT3fMKySvVoRENO/Diq2FoZq+3hNAbpC/H7iwMJPijhpZotQ0FEUs776eToAOdDe61g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.4.tgz",
+      "integrity": "sha512-A6GAcPa30KhWmYfqWhPHVZwVtJ/GBWDGbJZLddiZn1Ks5o2XX12orDWLwDpzs8hhx3NW4D3L5rrWLbLlywdKnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
-        "@wormhole-foundation/sdk-evm-core": "3.4.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-evm-core": "3.4.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2398,14 +2405,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.3.tgz",
-      "integrity": "sha512-Q3PLORl1uhJMz2ZkU/v4dcrS4VZ6Mfb58BNPjp/Tx8iFanVPu+QvLrFWF+G1KQMmcg8HqPTYlAgzKZ/fKQJBxw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.4.tgz",
+      "integrity": "sha512-hUYqrtv/P1VkbvBccWvk971QlsyzmPwnx4CN2qGVeoXH/Qi4S9MialsFmO5aCkjyEZG7VU/zXTsB4cI4Bk3gGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
-        "@wormhole-foundation/sdk-evm-core": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-evm-core": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2413,14 +2420,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-mUlzN7PJW6SFU0HOA+Ogs00TqLQ9p7I11vRDtWR6bGKIjluUD4+9CD6RoVHYzlhSPNh5VRjGdXr6WQmqaUjC7A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-VOnh25ATzuFqHOaBG8qYgN84hEvuWI3R95Y6bbQjUQePVHYqMXrwHkijdJTGucZJeQx8T06geKl/BOWIP/Wung==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-evm": "3.4.3",
-        "@wormhole-foundation/sdk-evm-core": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-evm-core": "3.4.4",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2428,16 +2435,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.3.tgz",
-      "integrity": "sha512-6hxpmwqlrhxyxZn6NweksGs6xG+6GvQQfkMath20QIDDPpqTkhQmvf+pslV6oEo7rjSlaoUJjCc3dlH4sU3PYg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.4.tgz",
+      "integrity": "sha512-vXis5ieZS8Pkge8qm0Sjokhn0J1F5MGc9GcUqTqxpsmw6/0EgMdxLCx9i10pW87dFwfQw4Uk8US91xKYU3+1LA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
+        "@wormhole-foundation/sdk-connect": "3.4.4",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2445,123 +2452,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.3.tgz",
-      "integrity": "sha512-cqXqkv7vvH/EvKGPA+dxUjOiYv5J9u5o/10RKDLKPLNnoDpSxwR6cIaR8xzfKIlsUFKghVk6xQZj+I1PpV3HZQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.4.tgz",
+      "integrity": "sha512-Ls7PIFRW5QyMaiJ7AeE11UC8T8HXEdMAlkNAbU7MF5/oF8RjTpIuZ9LS0ZbVXLJW5Saz+7ZcHg0yI23cDpwDuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-solana": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-solana": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.3.tgz",
-      "integrity": "sha512-godFR6rNFlJe9WwxRvKQrtCCV/L/HYMbK6ngMWK+qVZAOdVW4/INuMg9RZMh0Mpy0oxrfy2LgRX3pmyLnkJSCA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.4.tgz",
+      "integrity": "sha512-tCKWMwzOntpt96MsJQLUr0Vj/iBJdjX9vvX/JvZokIX5ZHAesosbvrVg9QX9GImX7pKCkqNltoH+SR07/cz9Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-solana": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-solana": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.3.tgz",
-      "integrity": "sha512-m27XhqxE3rtCzdfheclutqH/D5wxd6YusLFZV4yZqX7U5sUeWxQjfEIdIGpuLf0f9sWhrs7RZDK4lCvOrUhBXA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.4.tgz",
+      "integrity": "sha512-lgi62Y0YMi7mm0Tjz6TVJBMhDqX0l6w/p96nHuaPjKksqor1HJQBJdD9mTi0EKBq7glw5BB66zOw4nUUzlg5/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-solana": "3.4.3",
-        "@wormhole-foundation/sdk-solana-core": "3.4.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-solana": "3.4.4",
+        "@wormhole-foundation/sdk-solana-core": "3.4.4",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-canhTswghrINw7m9a8c59icLdcZ5yNwg6mok6LQwJLSUJvKUmehpTXWFRZ7acsxZfe199zm/sayEYVGIOaTAkw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-TS4YV2zwSqvMZ1FBO1pITCFTBucfgt6Uweox0szphdBVm+lQ9Snq78TqsPcJo5b1eWmMKA2N1UtrMJgVHMjmmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-solana": "3.4.3",
-        "@wormhole-foundation/sdk-solana-core": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-solana": "3.4.4",
+        "@wormhole-foundation/sdk-solana-core": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.3.tgz",
-      "integrity": "sha512-KUwQFhSkq2/uGlYKSAbUzOCY2wC3oHY5nNcbjO+IPm1VN6fa9c/k9XSbsDhAQQz1tmXd7/ebEeMuh6qV6nnj0Q==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.4.tgz",
+      "integrity": "sha512-r7WGiWI3O9jjyn94/gj0kpxI26LLA1pScfvTGVR5MHKwYmgRILXJANoQLU+lxXfvCk7lTT4E44TdK3uoHD+l3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.3.tgz",
-      "integrity": "sha512-1mwXgdytkAGraJllusU7hYmSkt8qxb/eaOi5gdiVA329uUfk6+SOuaHzntmSdesq+ZWtR9EogBvQqnn1+2iy5w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.4.tgz",
+      "integrity": "sha512-ecmlaF+1WK8Tfl7qOEYHM/Xkjh5Sa+ABN6IIGTJR5Vu3dEr7J4eb1u6K9BFzndJNB5XSr80TqCnU8HEjkD56nw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-sui": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-sui": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.3.tgz",
-      "integrity": "sha512-WvT1crdDVjKRL0ev9CUynhxlXmMz/+mscUfvnpQf+W/UgI1r7g1mHA1HWK/otJ+aEorR6yadRcg9/gxSg1RUXA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.4.tgz",
+      "integrity": "sha512-DvOcfBEmYp4lD3QcEw7by+sziiZb9UAWD3Aqu8NZ2SiYXCo67tA2t7TEzjMb9bCtSRDDWpe8ef3CI/tZTeb9tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-sui": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-sui": "3.4.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.3.tgz",
-      "integrity": "sha512-SVDJry7FYdmDSRLwwRUy6RkJ2zkMkUbfX6ujsGJ0d26SEV1hYKpGQ/BIMCflDLPZDXYIwkQ94M67M0BwXsLp9w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.4.tgz",
+      "integrity": "sha512-w+1uWCnfWNNJ9mhXByHt7lRsA9LhJwZNWtvjnZB0EiYB2SsHmRpYtpvVMrycQ3JQKhaHdoVlKG0h4B7tFvyDJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.3",
-        "@wormhole-foundation/sdk-sui": "3.4.3",
-        "@wormhole-foundation/sdk-sui-core": "3.4.3"
+        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-sui": "3.4.4",
+        "@wormhole-foundation/sdk-sui-core": "3.4.4"
       },
       "engines": {
         "node": ">=16"
@@ -4838,10 +4845,10 @@
         "proxy-agent": "^6.4.0"
       }
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/long": {

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.4.4",
+        "@wormhole-foundation/sdk": "3.4.5",
         "sharp": "^0.34.3",
         "swagger-markdown": "^3.0.0"
       },
@@ -2114,52 +2114,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.4.tgz",
-      "integrity": "sha512-8LgJsvR2AGzRYywjGvfAMBUBwOiJ7CQhIcjNpcvAOr/pTbpl/zlpI//Newi1LMrZ5rQNJMcHzlGwHGAWPjoMYA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.5.tgz",
+      "integrity": "sha512-NhqpjG0wxU2NKu7TMWlp+7sUQZys1atI06glFme2Y1jHiCOMrUn8F/tKriedVPjf+CE6GxBelx5pSFqbY4bTAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.4",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.4",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.4",
-        "@wormhole-foundation/sdk-aptos": "3.4.4",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.4.4",
-        "@wormhole-foundation/sdk-aptos-core": "3.4.4",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.4",
-        "@wormhole-foundation/sdk-base": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.4",
-        "@wormhole-foundation/sdk-definitions": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
-        "@wormhole-foundation/sdk-evm-cctp": "3.4.4",
-        "@wormhole-foundation/sdk-evm-core": "3.4.4",
-        "@wormhole-foundation/sdk-evm-portico": "3.4.4",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.4.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.4",
-        "@wormhole-foundation/sdk-solana": "3.4.4",
-        "@wormhole-foundation/sdk-solana-cctp": "3.4.4",
-        "@wormhole-foundation/sdk-solana-core": "3.4.4",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.4.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.4",
-        "@wormhole-foundation/sdk-sui": "3.4.4",
-        "@wormhole-foundation/sdk-sui-cctp": "3.4.4",
-        "@wormhole-foundation/sdk-sui-core": "3.4.4",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.4"
+        "@wormhole-foundation/sdk-algorand": "3.4.5",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.5",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-aptos": "3.4.5",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.4.5",
+        "@wormhole-foundation/sdk-aptos-core": "3.4.5",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-base": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-definitions": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-evm-cctp": "3.4.5",
+        "@wormhole-foundation/sdk-evm-core": "3.4.5",
+        "@wormhole-foundation/sdk-evm-portico": "3.4.5",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.4.5",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-solana": "3.4.5",
+        "@wormhole-foundation/sdk-solana-cctp": "3.4.5",
+        "@wormhole-foundation/sdk-solana-core": "3.4.5",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.4.5",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-sui": "3.4.5",
+        "@wormhole-foundation/sdk-sui-cctp": "3.4.5",
+        "@wormhole-foundation/sdk-sui-core": "3.4.5",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.4.tgz",
-      "integrity": "sha512-inwusqDtlHQ6DME5Rtn9vAyf0Sa48boQXc7Ci/ta1yAVrV00xkzvoz64Fy6lg3v54mFcdV04/d60Z/5r+A9JTA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.5.tgz",
+      "integrity": "sha512-woNM5+yFrU9VHRbYTj7XwPf6PnmLxx1xWghE0Ff2Vcm+ohMuZkUgn0WR+ItImmpshx15twB9PHpxT9IJDwruHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2167,89 +2167,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.4.tgz",
-      "integrity": "sha512-EeHlYy0TBFRjuzQKPMiWpuJDcsdjKHTvvTqkzysAWHhS4/zMou60g9BbSsMLcSJKPesJZGLPmDd2D7X4PAsN0g==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.5.tgz",
+      "integrity": "sha512-S+Z43oidmHqlFa9y7K68k9/r2wPlLByY8vVBRAAR+XCBOINiJm2sOEiyzerV7WkWQ4jErIVsJ9p9nIBbib1dkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-algorand": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-1OMkbNpBOH69m3hCjaHq3xiTSIUyU1LXpdJfSaSkbLnEqy5t2Ee8tHwyjf5vH6ti/0d26OST0lhGPkUl+5mlVA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-MAmSbFT/ComNA0XKGdZqomOWZQQjChxq8xPuVO0IwZkMH4rFgmNbTbDbiBP3uK3u+jEEw+OS+DMl+bX/7RpWnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.4",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-algorand": "3.4.5",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.4.tgz",
-      "integrity": "sha512-tGOML0ftOMpxI9oOb5/FYEjzhUofBxBrEKAE/hh5E/4eSIg9mCSp+wCQj0BDqlt6sRy36RwhJD3hvbYuwGC0ug==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.5.tgz",
+      "integrity": "sha512-ctIX5uE1tNhoDMZ1f4/JRkgoKJUvXUFrhH6CAnz7ry9ts+TVNWvIQuKz95SQxZb7ztWWkKTU1BRvHgoTB+l9Fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.4.tgz",
-      "integrity": "sha512-gGRgszsacPRTIXyA/CsMLgd3eJr3QnXwfFqpu93iO5NtuCkdddWpwyb2ukilBbd9dhJMMfB2iKhMCbV83G4Zfw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.5.tgz",
+      "integrity": "sha512-ASzd6lVd9FOiK911Xkq4jwt1OUZFh2jrdfOMCCr1RWPG06mQZusRNqhqO0d8jX0JXFJSTqZD14JxQ7G/5sZnNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-aptos": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.4.tgz",
-      "integrity": "sha512-2ePZzHuLiwqm3+egGM9YBixUy+PXHuwOZI5yZJfwPbrN4FALkC5EX9iKa+donsGlmT5I50TQHGSgXAESuTOVQw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.5.tgz",
+      "integrity": "sha512-J/3hRenXa0YRvvkJY7BPVl/pva+1vJamKp1I2kNggFIoCGLmo+GawAtqH8y6aHnDu8DEdxXP4JgF9JVgGP90dA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-aptos": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-O6TO0Z/aKBt3qc+HeDqMnH2xnX8SaqqE73T1ExtLS2qEdl0xLIAnQN0QR/HqoiUqxaTXecJNjusuQyDQA9McVA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-cTk6drjIjM/ZRMKVGGomzJgzlzqUIZpa053FSr++TVj1qW8DXQVJAie4qfDF04WAMGCq+XVeenQBY6ybQylupw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.4",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-aptos": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.4.tgz",
-      "integrity": "sha512-V5lZNBPr27wmbDUI1+cquaMGgxPllcMwnha+lFT3+RTxWY8+i/9xnOTjkcNknba3pRlOEq5u/c+GbX7JO3vsPw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.5.tgz",
+      "integrity": "sha512-/KY6PHJB4U9l+9/F25glkm9TPCBYiTZpN3I1Sg9049/h/07rXG4OhdogNSbLETekFRolLqw+hultOqghpg51bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2257,13 +2257,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.4.tgz",
-      "integrity": "sha512-01PNBa7yM9aXnpG72OC4F2sriORN+kmUIQMjT9zCtslDPfliysMEJ3DHFIyBK6uGyek+SPpeFzLZcFUAFlmbIA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.5.tgz",
+      "integrity": "sha512-RexHvcRIEdOL+FKhEtfdTI3luXI/3I5fzVOmKX0S4w8QBXu/HINqeySv1bFoA4x+BLoUwphOqyNDL3zke91aAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.4.4",
-        "@wormhole-foundation/sdk-definitions": "3.4.4",
+        "@wormhole-foundation/sdk-base": "3.4.5",
+        "@wormhole-foundation/sdk-definitions": "3.4.5",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2271,16 +2271,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.4.tgz",
-      "integrity": "sha512-VgDtmrjWLOrMsAF+auBVlMCCGgLbaGoOxdyrVwRgg/ofas1cPbOy4tU6tTLayefGd6dKUlX5CgECT1v3Iyez2Q==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.5.tgz",
+      "integrity": "sha512-qKZSLUtCuL+Cf9FfEfsXAYKfWbnvx2v/i/7e4AqbFyZWw8zSG9kwtP5b4X5w8fn5TB4ae94Md18efsLU9wFrOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2288,33 +2288,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.4.tgz",
-      "integrity": "sha512-X3hfbBKxvLXpG/tXZj9CoW7EJq6Him69y9tfxSj7nMMg+uQMdzLrMXqxo+BH4zImoWuTq6iFNNtmCoLYNklgiw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.5.tgz",
+      "integrity": "sha512-ghEkfGo1XQfLSVjvFbLTOJrc/3ZoVwoB6l34oWLqqwnqB/Bb8c6KU641YfXH1HAVHr4b7QErpcsQaF4KHxdn3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.4.tgz",
-      "integrity": "sha512-NSq+tO3tiCZVUfmOunofUumYkPdTIgyog297ZUfCUFY10ViuC9ITIIAFLsMMZWo9rOolaBRBFXFKxlPGPCa+Nw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.5.tgz",
+      "integrity": "sha512-bWeS3IQvUOMlgRQO82pUtWV8RZyTcfluEtrtcRmRFjD6De5IBccyTaF8WOlJ9yTR9k6S54BFf1J7cuS0Jq4KYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.5",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2322,37 +2322,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-6G8Dmrn/bOm+e1rLdQfF5RCXmiTsbw5LUMLFbAl8ycDFfoDu0IRhVfVuTT+HPHSsM4ZTbJMyTU8VqZO/E9pxpw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-ApxGQ8wCW6ARTuyYG/Zm2nDqYIoaCvtQ64NtD4fghnV+ls+H9/oVjEOrDJA56MHK1Qj8LvktzkP1mzJPoDm0TA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.4.tgz",
-      "integrity": "sha512-YWAp3fWRrBIIMcuaB5xqFiAjbMGIrALF+Yw3+tDD6sYumZfihEe/Qh3USjsngyFSSO0DO68ul8mG3CQ+erhssA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.5.tgz",
+      "integrity": "sha512-nklLuacNFLsv8fKGTYeTiVr5W67cUg+uFOOJvo0WJjKbunkgJ+Y1z9hTO95dmt2o/nKaHLsEvtUa++W+jqN+ag==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.4.4"
+        "@wormhole-foundation/sdk-base": "3.4.5"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.4.tgz",
-      "integrity": "sha512-0xNrN5RGL1KA0L19hWm4sax4U1uQKcl62BZJVoG/tj3yNczMajTOe8zfnDNiyW8HTr3/adIl6+bvcyxoJfqGdA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.5.tgz",
+      "integrity": "sha512-fVXx2S1VxewEvn7yVMN53NXduhDQm+qhzdwNLwa6xye56eOhDWThmldAX869jgA85/8/i3GkYZCFMlOr92Ke2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2360,14 +2360,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.4.tgz",
-      "integrity": "sha512-T/Bua4MGOLPZG+HsoNbgqsntpw1QRUuwX4stS4kHmQeNWqz3Mh+vARpmv9ZWhkMZjfDMJGeI4xf7JC782es2kQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.5.tgz",
+      "integrity": "sha512-kJs+fygcgwuFIaHud/edB6pCJuC8soaBt9mKEVRSqRgPCr0eCSePc//wzMRU9LA+DluaU6CrpKkk4m1Z7LzyQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
-        "@wormhole-foundation/sdk-evm-core": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-evm-core": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2375,13 +2375,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.4.tgz",
-      "integrity": "sha512-4uZuXWDET5b7bqbs4h09Fw8TgJCmLH/HYIpYy0qgcEvnJwsbw+ZtAvPkAQnSJaaANB3IHj+oZvyDci9Cz11lHg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.5.tgz",
+      "integrity": "sha512-VpOOXNSRAAEQ/EpqyDb/uRtHLM4X5Eqcl2uz5yt5yCi6tfiahAHUmsgD4kvJ1hM879RNHogq/gtS8mlVmDNnuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2389,15 +2389,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.4.tgz",
-      "integrity": "sha512-A6GAcPa30KhWmYfqWhPHVZwVtJ/GBWDGbJZLddiZn1Ks5o2XX12orDWLwDpzs8hhx3NW4D3L5rrWLbLlywdKnA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.5.tgz",
+      "integrity": "sha512-ZHW4ToNxP7dPYG6S5cdxq7Hvevs5/2U01ccljQrAfOYsTDMxyJyBAR9PfdOc6p+EcymYJcVqIOV9zo/tNbLm9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
-        "@wormhole-foundation/sdk-evm-core": "3.4.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-evm-core": "3.4.5",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2405,14 +2405,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.4.tgz",
-      "integrity": "sha512-hUYqrtv/P1VkbvBccWvk971QlsyzmPwnx4CN2qGVeoXH/Qi4S9MialsFmO5aCkjyEZG7VU/zXTsB4cI4Bk3gGw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.5.tgz",
+      "integrity": "sha512-9iqqkR0wswyxx/MQkrPBuNYkNYEmYmHdX396onDiXDJ/LUKcY1JVTHr2YwWxK8aQ2wLowol/7HJCilzjgVJg5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
-        "@wormhole-foundation/sdk-evm-core": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-evm-core": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2420,14 +2420,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-VOnh25ATzuFqHOaBG8qYgN84hEvuWI3R95Y6bbQjUQePVHYqMXrwHkijdJTGucZJeQx8T06geKl/BOWIP/Wung==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-BeKVacnqVpM/zS8Gtm6YhpI54fCS8bnP0JIPi0HfvbEFZK4j15djbmYNZ59ZptmkEqAr4nids9N9ewQfwANr4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-evm": "3.4.4",
-        "@wormhole-foundation/sdk-evm-core": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-evm-core": "3.4.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2435,16 +2435,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.4.tgz",
-      "integrity": "sha512-vXis5ieZS8Pkge8qm0Sjokhn0J1F5MGc9GcUqTqxpsmw6/0EgMdxLCx9i10pW87dFwfQw4Uk8US91xKYU3+1LA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.5.tgz",
+      "integrity": "sha512-zk19Sma6z41O5tHIHefMgxP1jbm3czjaPCX6rstcdCWskpJ1MNoIHQfYe98MMxDDSmGBwvr6eV+NSdC2qXAuMw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
+        "@wormhole-foundation/sdk-connect": "3.4.5",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2452,123 +2452,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.4.tgz",
-      "integrity": "sha512-Ls7PIFRW5QyMaiJ7AeE11UC8T8HXEdMAlkNAbU7MF5/oF8RjTpIuZ9LS0ZbVXLJW5Saz+7ZcHg0yI23cDpwDuw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.5.tgz",
+      "integrity": "sha512-ouTr98DdwMDIvIkhE694x4Dx0JpBE+PFLoYRiWx0UudoixvDz54zcnIpTs3sabW0jd6tB0SvHCHUfQQd1EqVyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-solana": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-solana": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.4.tgz",
-      "integrity": "sha512-tCKWMwzOntpt96MsJQLUr0Vj/iBJdjX9vvX/JvZokIX5ZHAesosbvrVg9QX9GImX7pKCkqNltoH+SR07/cz9Uw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.5.tgz",
+      "integrity": "sha512-u1KyBHeZegwkMoS6BRYC5AB1VExFrxXOBaXhOVqjeVL7TGOZCJf5otLARwYmBPb7U60f9FfWvDdtnqdd6rRBzA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-solana": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-solana": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.4.tgz",
-      "integrity": "sha512-lgi62Y0YMi7mm0Tjz6TVJBMhDqX0l6w/p96nHuaPjKksqor1HJQBJdD9mTi0EKBq7glw5BB66zOw4nUUzlg5/g==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.5.tgz",
+      "integrity": "sha512-UTZXZIuihihYyCTAZFoKoGE9PQYCJHaU83ion/n0Uvn/M4cF8zea2mlV9U0seiNPCA/JUu8BvyCvF8wzk0eMNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-solana": "3.4.4",
-        "@wormhole-foundation/sdk-solana-core": "3.4.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-solana": "3.4.5",
+        "@wormhole-foundation/sdk-solana-core": "3.4.5",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-TS4YV2zwSqvMZ1FBO1pITCFTBucfgt6Uweox0szphdBVm+lQ9Snq78TqsPcJo5b1eWmMKA2N1UtrMJgVHMjmmQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-RePgTpcWsCRAv9tcKQy4hPTANyBiDsY4pNsULizDfNZJUdCTag1JxS1VBifTImJ/XK4UG9BhfZhn0aklkX2sZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-solana": "3.4.4",
-        "@wormhole-foundation/sdk-solana-core": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-solana": "3.4.5",
+        "@wormhole-foundation/sdk-solana-core": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.4.tgz",
-      "integrity": "sha512-r7WGiWI3O9jjyn94/gj0kpxI26LLA1pScfvTGVR5MHKwYmgRILXJANoQLU+lxXfvCk7lTT4E44TdK3uoHD+l3w==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.5.tgz",
+      "integrity": "sha512-7aI97fB4Icem5OgsrTsWsVkT/911J5m6HsKsykEf5zZFSV6FzoOo6n3BO6Eu5AfwcTDcZ/BxhPKF7NYZYY0IqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.4.tgz",
-      "integrity": "sha512-ecmlaF+1WK8Tfl7qOEYHM/Xkjh5Sa+ABN6IIGTJR5Vu3dEr7J4eb1u6K9BFzndJNB5XSr80TqCnU8HEjkD56nw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.5.tgz",
+      "integrity": "sha512-J8gTkDtK/kQKr+PI/MtBPhaR3LlSPA3L9LBvxsmhzrmJYUOq+j7nIgQyVP+KmCI/a2+3s0etDWl8B4xEibl69g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-sui": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-sui": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.4.tgz",
-      "integrity": "sha512-DvOcfBEmYp4lD3QcEw7by+sziiZb9UAWD3Aqu8NZ2SiYXCo67tA2t7TEzjMb9bCtSRDDWpe8ef3CI/tZTeb9tw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.5.tgz",
+      "integrity": "sha512-KI421Hqh4mnADEgsoekjrpKwqsPh0pQEN4F9+1p6bJY8kdzjrx92gvxtcrt8yZtyUYIJLwzkkUx+iz5t1aV3lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-sui": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-sui": "3.4.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.4.tgz",
-      "integrity": "sha512-w+1uWCnfWNNJ9mhXByHt7lRsA9LhJwZNWtvjnZB0EiYB2SsHmRpYtpvVMrycQ3JQKhaHdoVlKG0h4B7tFvyDJQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.5.tgz",
+      "integrity": "sha512-zSOUG2e+JRxdSsB0u7+pkZgoGqX4WniRSM3lbYxS5EAsfGw1UTkEBLVEmqOS5jGLbocUsSR4AkH2L9C4zJRCsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.4",
-        "@wormhole-foundation/sdk-sui": "3.4.4",
-        "@wormhole-foundation/sdk-sui-core": "3.4.4"
+        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-sui": "3.4.5",
+        "@wormhole-foundation/sdk-sui-core": "3.4.5"
       },
       "engines": {
         "node": ">=16"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.4.4",
+    "@wormhole-foundation/sdk": "3.4.5",
     "sharp": "^0.34.3",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.4.3",
+    "@wormhole-foundation/sdk": "3.4.4",
     "sharp": "^0.34.3",
     "swagger-markdown": "^3.0.0"
   }


### PR DESCRIPTION
This pull request updates several dependencies in the `scripts/package-lock.json` file to their latest versions, improving compatibility and security. The most notable changes are version bumps for major SDKs and utility libraries, and an adjustment to the lodash dependency.

Dependency updates:

* Upgraded `@wormhole-foundation/sdk` from version 3.4.3 to 3.4.5 for improved features and bug fixes.
* Upgraded `@mysten/sui` from version 1.37.4 to 1.37.5 for the latest improvements and fixes.
* Upgraded `@metamask/utils` from version 11.4.2 to 11.5.0, switched from `lodash.memoize` to the full `lodash` package, and added `@types/lodash` for TypeScript support.

Type definitions:

* Added `@types/lodash` at version 4.17.20 to support TypeScript type checking for lodash usage.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/609