### PR TITLE
Update SDK to the latest version

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.4.5",
+        "@wormhole-foundation/sdk": "3.4.6",
         "sharp": "^0.34.3",
         "swagger-markdown": "^3.0.0"
       },
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.5.0.tgz",
-      "integrity": "sha512-fgPTBWyFhGp8VZ5HsWniY5qZIb9DfusRB8ssw8unGIomICCK+cnEcV2xajhpPJ6QPH62y1KyVHF+VbXKrgilLA==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.7.0.tgz",
+      "integrity": "sha512-IamqpZF8Lr4WeXJ84fD+Sy+v1Zo05SYuMPHHBrZWpzVbnHAmXQpL4ckn9s5dfA+zylp3WGypaBPb6SBZdOhuNQ==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.37.5",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.5.tgz",
-      "integrity": "sha512-kAKizRUdhC/gwQ7UkubbmwTno5UoA1a7Ps8R6GlPVWpCfpVM2HytmwFDOKVMA+51Qji4BaNxyq25SRpJw76fPw==",
+      "version": "1.37.6",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.6.tgz",
+      "integrity": "sha512-7ut5tWuXx9OIE+DQ2D5hd22UB8j8K4/F2Lx3R8Ej/JMwkm6cpgbF5FKNu0vYqehxiFEktMnq2YzzajxmlFHNPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -1540,7 +1540,7 @@
         "@scure/bip39": "^1.6.0",
         "gql.tada": "^1.8.12",
         "graphql": "^16.11.0",
-        "poseidon-lite": "^0.2.0",
+        "poseidon-lite": "0.2.1",
         "valibot": "^0.36.0"
       },
       "engines": {
@@ -2114,52 +2114,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.5.tgz",
-      "integrity": "sha512-NhqpjG0wxU2NKu7TMWlp+7sUQZys1atI06glFme2Y1jHiCOMrUn8F/tKriedVPjf+CE6GxBelx5pSFqbY4bTAg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.6.tgz",
+      "integrity": "sha512-lKuyvWNK5EC4hv9W4nwvo2I25A1/B3En+HsvngS5HBP4wnL+HKOdhfh02b50nWJORpZoHrJfOapJ0ZeVhCpA9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.5",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.5",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.5",
-        "@wormhole-foundation/sdk-aptos": "3.4.5",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.4.5",
-        "@wormhole-foundation/sdk-aptos-core": "3.4.5",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.5",
-        "@wormhole-foundation/sdk-base": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.5",
-        "@wormhole-foundation/sdk-definitions": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
-        "@wormhole-foundation/sdk-evm-cctp": "3.4.5",
-        "@wormhole-foundation/sdk-evm-core": "3.4.5",
-        "@wormhole-foundation/sdk-evm-portico": "3.4.5",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.4.5",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.5",
-        "@wormhole-foundation/sdk-solana": "3.4.5",
-        "@wormhole-foundation/sdk-solana-cctp": "3.4.5",
-        "@wormhole-foundation/sdk-solana-core": "3.4.5",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.4.5",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.5",
-        "@wormhole-foundation/sdk-sui": "3.4.5",
-        "@wormhole-foundation/sdk-sui-cctp": "3.4.5",
-        "@wormhole-foundation/sdk-sui-core": "3.4.5",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.5"
+        "@wormhole-foundation/sdk-algorand": "3.4.6",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.6",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-aptos": "3.4.6",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.4.6",
+        "@wormhole-foundation/sdk-aptos-core": "3.4.6",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-base": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-definitions": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-evm-cctp": "3.4.6",
+        "@wormhole-foundation/sdk-evm-core": "3.4.6",
+        "@wormhole-foundation/sdk-evm-portico": "3.4.6",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.4.6",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-solana": "3.4.6",
+        "@wormhole-foundation/sdk-solana-cctp": "3.4.6",
+        "@wormhole-foundation/sdk-solana-core": "3.4.6",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.4.6",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-sui": "3.4.6",
+        "@wormhole-foundation/sdk-sui-cctp": "3.4.6",
+        "@wormhole-foundation/sdk-sui-core": "3.4.6",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.5.tgz",
-      "integrity": "sha512-woNM5+yFrU9VHRbYTj7XwPf6PnmLxx1xWghE0Ff2Vcm+ohMuZkUgn0WR+ItImmpshx15twB9PHpxT9IJDwruHQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.6.tgz",
+      "integrity": "sha512-sxSnR10OByR9jItoLmOEvUpxriIi0QoRKM+Tvcd2bs0eR9UqM9R74K4n6I7g4OrMMg4o7huduE192otiKxV8PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2167,89 +2167,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.5.tgz",
-      "integrity": "sha512-S+Z43oidmHqlFa9y7K68k9/r2wPlLByY8vVBRAAR+XCBOINiJm2sOEiyzerV7WkWQ4jErIVsJ9p9nIBbib1dkg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.6.tgz",
+      "integrity": "sha512-k9ggDEVQmNsc86GKac7k+5O/obV8XV7cTUciuYxQxlFNgfkFVnv/S1F5Ykx5e+auThQuuH+SWJrwFwysUtxHEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-algorand": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-MAmSbFT/ComNA0XKGdZqomOWZQQjChxq8xPuVO0IwZkMH4rFgmNbTbDbiBP3uK3u+jEEw+OS+DMl+bX/7RpWnw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-67/g6dDqRmLLqTdXVG1VphxWn+jMx65z6nefM4lfOQdGXzYpTbrY+qHX8mMJinRBiIBwxRdz4fEW1ukFW2nnAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.5",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-algorand": "3.4.6",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.5.tgz",
-      "integrity": "sha512-ctIX5uE1tNhoDMZ1f4/JRkgoKJUvXUFrhH6CAnz7ry9ts+TVNWvIQuKz95SQxZb7ztWWkKTU1BRvHgoTB+l9Fw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.6.tgz",
+      "integrity": "sha512-w7aGkKlBXqsHMXYCcV6P7hIJXCp7QRq+jw9jnXZWJSXddG4z0IDoRgPOYajUPyYtL3GbLS+TzNXoR8GErijuBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.5.tgz",
-      "integrity": "sha512-ASzd6lVd9FOiK911Xkq4jwt1OUZFh2jrdfOMCCr1RWPG06mQZusRNqhqO0d8jX0JXFJSTqZD14JxQ7G/5sZnNQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.6.tgz",
+      "integrity": "sha512-PpRFLguLtb8GXJ31P7tXPPpVQsZT9A5VlRx1bjTrRbg5cLQ5gpR73JiBk8lLvEf6av5ay8FRPmtVvaU7W65QwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-aptos": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.5.tgz",
-      "integrity": "sha512-J/3hRenXa0YRvvkJY7BPVl/pva+1vJamKp1I2kNggFIoCGLmo+GawAtqH8y6aHnDu8DEdxXP4JgF9JVgGP90dA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.6.tgz",
+      "integrity": "sha512-JZ6lEcQ5jS9oX4yLdiOx4peSbzsucGozYqT36THxrim7pGUt+pEO5sFE07NcjAHg51+J3mP8do1IDzELmoXTfg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-aptos": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-cTk6drjIjM/ZRMKVGGomzJgzlzqUIZpa053FSr++TVj1qW8DXQVJAie4qfDF04WAMGCq+XVeenQBY6ybQylupw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-qRk7HH5IzNzBKWc6Lg4msyxCu9Pplr41qp4INxJ2W2CJ9fOSHj9z+zFh3gf4r9EVgXs3qR5kG9FxtyITykLFWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.5",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-aptos": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.5.tgz",
-      "integrity": "sha512-/KY6PHJB4U9l+9/F25glkm9TPCBYiTZpN3I1Sg9049/h/07rXG4OhdogNSbLETekFRolLqw+hultOqghpg51bA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.6.tgz",
+      "integrity": "sha512-fcVrLGptGFJ1OGyQlYZ37+8XBSLAw9+NVvTpJaEGoFp185YEknxPEo0VkV4m5iPVKEvSjwJxQcVreDTYsVBu7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2257,13 +2257,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.5.tgz",
-      "integrity": "sha512-RexHvcRIEdOL+FKhEtfdTI3luXI/3I5fzVOmKX0S4w8QBXu/HINqeySv1bFoA4x+BLoUwphOqyNDL3zke91aAQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.6.tgz",
+      "integrity": "sha512-jPPSferW8Y4Re36EiSimmgLjyzyxmvlhyUxCSxYJS97RN9mEafaiJc5vM3E4+whTzUX434ihI8fwoyx3hUupsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.4.5",
-        "@wormhole-foundation/sdk-definitions": "3.4.5",
+        "@wormhole-foundation/sdk-base": "3.4.6",
+        "@wormhole-foundation/sdk-definitions": "3.4.6",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2271,16 +2271,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.5.tgz",
-      "integrity": "sha512-qKZSLUtCuL+Cf9FfEfsXAYKfWbnvx2v/i/7e4AqbFyZWw8zSG9kwtP5b4X5w8fn5TB4ae94Md18efsLU9wFrOQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.6.tgz",
+      "integrity": "sha512-6U5U0+XhjC0P6gF9f+FRUD3VZCY1dvwHEMQBsFr0cFljrzqCR6C3/tVhpD5nNdPBYbV65bsPmlZNCUVq77vI4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2288,33 +2288,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.5.tgz",
-      "integrity": "sha512-ghEkfGo1XQfLSVjvFbLTOJrc/3ZoVwoB6l34oWLqqwnqB/Bb8c6KU641YfXH1HAVHr4b7QErpcsQaF4KHxdn3g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.6.tgz",
+      "integrity": "sha512-QMXPxWubWA3Sy1+BdvKSJLF4ZHIMaJFzpBQoksN1uxn3sLdoW3PpKRuLgokF5uQAS+08GjGzJOV132ktXkAnnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.5.tgz",
-      "integrity": "sha512-bWeS3IQvUOMlgRQO82pUtWV8RZyTcfluEtrtcRmRFjD6De5IBccyTaF8WOlJ9yTR9k6S54BFf1J7cuS0Jq4KYg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.6.tgz",
+      "integrity": "sha512-l1MD3GmU6Xnt50NDRGc1NwROclNaAkQNlKydgcwiRRBwPEB8LjSGrcL2NzQ11YnG9snA2QpzFgZIK+jPgn54Og==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.6",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2322,37 +2322,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-ApxGQ8wCW6ARTuyYG/Zm2nDqYIoaCvtQ64NtD4fghnV+ls+H9/oVjEOrDJA56MHK1Qj8LvktzkP1mzJPoDm0TA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-t7YjOGVxPjfB5uIhHIWCyulDe56ikaJ8JKkfY3x//k8qsLUtpR663u43Hho/X/CbLiywpxk1ATQWzDXBbSxBkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.5.tgz",
-      "integrity": "sha512-nklLuacNFLsv8fKGTYeTiVr5W67cUg+uFOOJvo0WJjKbunkgJ+Y1z9hTO95dmt2o/nKaHLsEvtUa++W+jqN+ag==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.6.tgz",
+      "integrity": "sha512-w1RS3OeHKoMN385t9kWFIrLyH57brCXbQbioMjaGY4DVrsFU3Xd3iqvm1je94yEBEbieJUc7+oxQDEh/AKtN4w==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.4.5"
+        "@wormhole-foundation/sdk-base": "3.4.6"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.5.tgz",
-      "integrity": "sha512-fVXx2S1VxewEvn7yVMN53NXduhDQm+qhzdwNLwa6xye56eOhDWThmldAX869jgA85/8/i3GkYZCFMlOr92Ke2w==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.6.tgz",
+      "integrity": "sha512-mqAc8ALw3P3gc57dPW2cIf8yniljOKU3rrrX89deucFvImE1pUHYG6b/z2paDXuV574nT11pXfsxpFYTMX+bTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2360,14 +2360,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.5.tgz",
-      "integrity": "sha512-kJs+fygcgwuFIaHud/edB6pCJuC8soaBt9mKEVRSqRgPCr0eCSePc//wzMRU9LA+DluaU6CrpKkk4m1Z7LzyQA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.6.tgz",
+      "integrity": "sha512-KQirzy7Ay851uxPs4LfWppvFosUJ3TH5O91ONvdl9ClBrA+h8QDv44OYzJMae477zy1SJYzRhRbhHTxoMp6m8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
-        "@wormhole-foundation/sdk-evm-core": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-evm-core": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2375,13 +2375,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.5.tgz",
-      "integrity": "sha512-VpOOXNSRAAEQ/EpqyDb/uRtHLM4X5Eqcl2uz5yt5yCi6tfiahAHUmsgD4kvJ1hM879RNHogq/gtS8mlVmDNnuA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.6.tgz",
+      "integrity": "sha512-7M6ZjMJIiKkoUk/1dk2tJgM3rTbJxrKTNg9aHN2AhCQBxU/+7UMZslmuq8WlbnxKY/cc5ZS7WQA7rJVtWjZsUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2389,15 +2389,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.5.tgz",
-      "integrity": "sha512-ZHW4ToNxP7dPYG6S5cdxq7Hvevs5/2U01ccljQrAfOYsTDMxyJyBAR9PfdOc6p+EcymYJcVqIOV9zo/tNbLm9A==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.6.tgz",
+      "integrity": "sha512-xEStFlKEJCFwzNkyQ/oCn79sEqaAas95LC3OcWVyH0vr0GzJXf6OGL8Dq52LHUKcuUR8UtYcPWcFLIpA62pdcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
-        "@wormhole-foundation/sdk-evm-core": "3.4.5",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-evm-core": "3.4.6",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2405,14 +2405,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.5.tgz",
-      "integrity": "sha512-9iqqkR0wswyxx/MQkrPBuNYkNYEmYmHdX396onDiXDJ/LUKcY1JVTHr2YwWxK8aQ2wLowol/7HJCilzjgVJg5Q==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.6.tgz",
+      "integrity": "sha512-DmQmAWJ45H0ByAIgei3PgCpvFDSyIxJ6+kM4/7/4svt10m4SxBPYgqTXQrEbedN9gNhsiM77SZF0RJscQxbCLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
-        "@wormhole-foundation/sdk-evm-core": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-evm-core": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2420,14 +2420,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-BeKVacnqVpM/zS8Gtm6YhpI54fCS8bnP0JIPi0HfvbEFZK4j15djbmYNZ59ZptmkEqAr4nids9N9ewQfwANr4A==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-XAzlTvTxkUSYi5p35hwMqrNSlQ9yWTAhNkO9HKWJVsimR1kTBwk4M0Pj9k4iiYDqP//AXDdxQOgM70ZMKUzAHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-evm": "3.4.5",
-        "@wormhole-foundation/sdk-evm-core": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-evm-core": "3.4.6",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2435,16 +2435,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.5.tgz",
-      "integrity": "sha512-zk19Sma6z41O5tHIHefMgxP1jbm3czjaPCX6rstcdCWskpJ1MNoIHQfYe98MMxDDSmGBwvr6eV+NSdC2qXAuMw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.6.tgz",
+      "integrity": "sha512-Css4Ob0J7LLwCVDRlYSxrH3ML4uNTakMF0foT2hk65hkjfq6rofuqocv5nqn+R0badmgQHctjxuQ+/NYiB5a9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
+        "@wormhole-foundation/sdk-connect": "3.4.6",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2452,123 +2452,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.5.tgz",
-      "integrity": "sha512-ouTr98DdwMDIvIkhE694x4Dx0JpBE+PFLoYRiWx0UudoixvDz54zcnIpTs3sabW0jd6tB0SvHCHUfQQd1EqVyQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.6.tgz",
+      "integrity": "sha512-EhS4L1UeW6yRNuXQU9tX5857T9o2muBvdIKEie/YSnsZ+d3gg6/XWRum+a2WYc9kasPIte3ugOgs6hC7g9sqgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-solana": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-solana": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.5.tgz",
-      "integrity": "sha512-u1KyBHeZegwkMoS6BRYC5AB1VExFrxXOBaXhOVqjeVL7TGOZCJf5otLARwYmBPb7U60f9FfWvDdtnqdd6rRBzA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.6.tgz",
+      "integrity": "sha512-BXqIEFVPU6VXGeXLbu6wOYCS1MmvAeobML+KnQetj5C9RWOIIG4jwwMyg8YXdqgHO+J/uxrfDZYCAtYfUNu/Ow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-solana": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-solana": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.5.tgz",
-      "integrity": "sha512-UTZXZIuihihYyCTAZFoKoGE9PQYCJHaU83ion/n0Uvn/M4cF8zea2mlV9U0seiNPCA/JUu8BvyCvF8wzk0eMNQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.6.tgz",
+      "integrity": "sha512-CtU3QMrBHeJA28isvwf/DyC5FdmDb3hZSPGQ8yIhx8UKYFzSrD2TiVCE00+Tk1SgkMW1cSohMe+6msrj90dvoA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-solana": "3.4.5",
-        "@wormhole-foundation/sdk-solana-core": "3.4.5",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-solana": "3.4.6",
+        "@wormhole-foundation/sdk-solana-core": "3.4.6",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-RePgTpcWsCRAv9tcKQy4hPTANyBiDsY4pNsULizDfNZJUdCTag1JxS1VBifTImJ/XK4UG9BhfZhn0aklkX2sZQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-hNw9eNpLUTjma75MYb2qTFkKmB+jUme9nr8oTgMVJ5x1zas7IXgd9Wd992XIaPCM36FYSivlezUBpFp14bHD6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-solana": "3.4.5",
-        "@wormhole-foundation/sdk-solana-core": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-solana": "3.4.6",
+        "@wormhole-foundation/sdk-solana-core": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.5.tgz",
-      "integrity": "sha512-7aI97fB4Icem5OgsrTsWsVkT/911J5m6HsKsykEf5zZFSV6FzoOo6n3BO6Eu5AfwcTDcZ/BxhPKF7NYZYY0IqA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.6.tgz",
+      "integrity": "sha512-MzGSrYr8LFBzow2OChIKHmYsTiUeNI6CFOlx89r31ZsKdhF72zLnfoldegg5qQdlvT9X9+xoRcYHzRsOc1yawQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.5.tgz",
-      "integrity": "sha512-J8gTkDtK/kQKr+PI/MtBPhaR3LlSPA3L9LBvxsmhzrmJYUOq+j7nIgQyVP+KmCI/a2+3s0etDWl8B4xEibl69g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.6.tgz",
+      "integrity": "sha512-Mgdg+vIJCq4lGQzbvEOrqkIiOg4GhZytIRLjuZ9vpgV5ZMiWbl9LpVFQ7i70yPv0mU/SFUy6VNkr2SECnDQsVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-sui": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-sui": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.5.tgz",
-      "integrity": "sha512-KI421Hqh4mnADEgsoekjrpKwqsPh0pQEN4F9+1p6bJY8kdzjrx92gvxtcrt8yZtyUYIJLwzkkUx+iz5t1aV3lg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.6.tgz",
+      "integrity": "sha512-oNKm3dPW0BZ5xGheOOg+0lt2FHwLw76jsJ/SZXYll2W3RSToLJkdZ9XMPeMLI4aSVGHftrweRCF2pKj/ghwZMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-sui": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-sui": "3.4.6"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.5.tgz",
-      "integrity": "sha512-zSOUG2e+JRxdSsB0u7+pkZgoGqX4WniRSM3lbYxS5EAsfGw1UTkEBLVEmqOS5jGLbocUsSR4AkH2L9C4zJRCsA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.6.tgz",
+      "integrity": "sha512-ohZVO3elXptPig39x0xM5dpyB46JZiFFEfn9hT5uK3nzNzyVEu/E1U0L5BpOp6rdkZDFEWgn2g552wrAUS5+HA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.5",
-        "@wormhole-foundation/sdk-sui": "3.4.5",
-        "@wormhole-foundation/sdk-sui-core": "3.4.5"
+        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-sui": "3.4.6",
+        "@wormhole-foundation/sdk-sui-core": "3.4.6"
       },
       "engines": {
         "node": ">=16"

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.4.6",
+        "@wormhole-foundation/sdk": "3.4.7",
         "sharp": "^0.34.3",
         "swagger-markdown": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "^24.3.0",
+        "@types/node": "^24.3.1",
         "markdown-link-check": "^3.13.7",
         "typescript": "^5.9.2"
       }
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2062,9 +2062,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -2114,52 +2114,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.6.tgz",
-      "integrity": "sha512-lKuyvWNK5EC4hv9W4nwvo2I25A1/B3En+HsvngS5HBP4wnL+HKOdhfh02b50nWJORpZoHrJfOapJ0ZeVhCpA9w==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.7.tgz",
+      "integrity": "sha512-9yuyBtN/BESr8pB2BCLWsRd3fT1Ef6BZapoV7++CW/F2cqcXkmdBGJjhJTJilhpn4HJkYtnfdKAk5BP9Pzwolw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.6",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.6",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.6",
-        "@wormhole-foundation/sdk-aptos": "3.4.6",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.4.6",
-        "@wormhole-foundation/sdk-aptos-core": "3.4.6",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.6",
-        "@wormhole-foundation/sdk-base": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.6",
-        "@wormhole-foundation/sdk-definitions": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
-        "@wormhole-foundation/sdk-evm-cctp": "3.4.6",
-        "@wormhole-foundation/sdk-evm-core": "3.4.6",
-        "@wormhole-foundation/sdk-evm-portico": "3.4.6",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.4.6",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.6",
-        "@wormhole-foundation/sdk-solana": "3.4.6",
-        "@wormhole-foundation/sdk-solana-cctp": "3.4.6",
-        "@wormhole-foundation/sdk-solana-core": "3.4.6",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.4.6",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.6",
-        "@wormhole-foundation/sdk-sui": "3.4.6",
-        "@wormhole-foundation/sdk-sui-cctp": "3.4.6",
-        "@wormhole-foundation/sdk-sui-core": "3.4.6",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.6"
+        "@wormhole-foundation/sdk-algorand": "3.4.7",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.7",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-aptos": "3.4.7",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.4.7",
+        "@wormhole-foundation/sdk-aptos-core": "3.4.7",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-base": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-definitions": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-evm-cctp": "3.4.7",
+        "@wormhole-foundation/sdk-evm-core": "3.4.7",
+        "@wormhole-foundation/sdk-evm-portico": "3.4.7",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.4.7",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-solana": "3.4.7",
+        "@wormhole-foundation/sdk-solana-cctp": "3.4.7",
+        "@wormhole-foundation/sdk-solana-core": "3.4.7",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.4.7",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-sui": "3.4.7",
+        "@wormhole-foundation/sdk-sui-cctp": "3.4.7",
+        "@wormhole-foundation/sdk-sui-core": "3.4.7",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.6.tgz",
-      "integrity": "sha512-sxSnR10OByR9jItoLmOEvUpxriIi0QoRKM+Tvcd2bs0eR9UqM9R74K4n6I7g4OrMMg4o7huduE192otiKxV8PQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.7.tgz",
+      "integrity": "sha512-FenOZxrL0dXwmggmViroJjvhNGGk5PqBHZh9zPyU7RRgdRJW7Gcc3MWvbggPJnpEqdMGCArwChdt7uj9y6TfUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2167,89 +2167,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.6.tgz",
-      "integrity": "sha512-k9ggDEVQmNsc86GKac7k+5O/obV8XV7cTUciuYxQxlFNgfkFVnv/S1F5Ykx5e+auThQuuH+SWJrwFwysUtxHEg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.7.tgz",
+      "integrity": "sha512-K6ajwBA2w2gWreDUAviQowaPjSFde8gO7m0Jq0Rr7j/Z/qLWIdAif5A2PFPWJJzuDtWkN01uoRDw+3LJFoAnZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-algorand": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-67/g6dDqRmLLqTdXVG1VphxWn+jMx65z6nefM4lfOQdGXzYpTbrY+qHX8mMJinRBiIBwxRdz4fEW1ukFW2nnAw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-nz9Msh5vFaoUfWg+kXyrf9deTG3mGT5CsqXloyvr023FzKCXfLwyNrmrqRbUmSUtZTk+0nk8Mm4SoI9+oxzT+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.6",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-algorand": "3.4.7",
+        "@wormhole-foundation/sdk-algorand-core": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.6.tgz",
-      "integrity": "sha512-w7aGkKlBXqsHMXYCcV6P7hIJXCp7QRq+jw9jnXZWJSXddG4z0IDoRgPOYajUPyYtL3GbLS+TzNXoR8GErijuBQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.7.tgz",
+      "integrity": "sha512-kY+0sGL+UUneA+TDuHHBBYaD/gp9sdec6iCpKPXIqCk6PzIzbGTnDq0ZhJ8YXRLNY/enQ1RZUlHjvIr6rzz6cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.6.tgz",
-      "integrity": "sha512-PpRFLguLtb8GXJ31P7tXPPpVQsZT9A5VlRx1bjTrRbg5cLQ5gpR73JiBk8lLvEf6av5ay8FRPmtVvaU7W65QwA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.7.tgz",
+      "integrity": "sha512-G6pJtx12E1CHNRt9b8gD1tJNWZ/BGne5PN/0iWm9CQ60wEdzGEzIpAwYyJMatyrgidtoGwVB9xV4W26eKbmFFQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-aptos": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.6.tgz",
-      "integrity": "sha512-JZ6lEcQ5jS9oX4yLdiOx4peSbzsucGozYqT36THxrim7pGUt+pEO5sFE07NcjAHg51+J3mP8do1IDzELmoXTfg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.7.tgz",
+      "integrity": "sha512-T50Od7BkpT/ASIBIX6XnUsndXWxnbbKPumtqb+/k85N0SPndwqmWZK35IEEsBIU7a0P3yDt/U47u4fqXjYUupQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-aptos": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-qRk7HH5IzNzBKWc6Lg4msyxCu9Pplr41qp4INxJ2W2CJ9fOSHj9z+zFh3gf4r9EVgXs3qR5kG9FxtyITykLFWg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-R6rdD7B4v3hWT6ktUREaMGIypA5wFaS6WlPdF2hYriV0T9SGsHC+lwiL2Gm9Xyx0oMGweFSSnEPEAvB43b32ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.6",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-aptos": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.6.tgz",
-      "integrity": "sha512-fcVrLGptGFJ1OGyQlYZ37+8XBSLAw9+NVvTpJaEGoFp185YEknxPEo0VkV4m5iPVKEvSjwJxQcVreDTYsVBu7w==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.7.tgz",
+      "integrity": "sha512-m4gYwE7O5/+p5e2tPLbcWrdncKAIOgaM+jC4p+yNfApA0wSOltYAGm0eCsc49mJdkpJsfwNvW+8Q5K45E3NmWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2257,13 +2257,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.6.tgz",
-      "integrity": "sha512-jPPSferW8Y4Re36EiSimmgLjyzyxmvlhyUxCSxYJS97RN9mEafaiJc5vM3E4+whTzUX434ihI8fwoyx3hUupsA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.7.tgz",
+      "integrity": "sha512-O9deBV7l46wK50yfhnWf8y9oI/UsFcdZIdnwISh/dmmxpfOymPSZpGI5YCPefhmAM4I450ALaXscjslWBvvU2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.4.6",
-        "@wormhole-foundation/sdk-definitions": "3.4.6",
+        "@wormhole-foundation/sdk-base": "3.4.7",
+        "@wormhole-foundation/sdk-definitions": "3.4.7",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2271,16 +2271,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.6.tgz",
-      "integrity": "sha512-6U5U0+XhjC0P6gF9f+FRUD3VZCY1dvwHEMQBsFr0cFljrzqCR6C3/tVhpD5nNdPBYbV65bsPmlZNCUVq77vI4Q==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.7.tgz",
+      "integrity": "sha512-2+q131H5uWYSmHYiLPMS4i5rHQ/yIkQyeoQLehmBFtWKMWnJJ/93Va4b2uhwP8/e4bRtz2QR79eRPTiCSXiiDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2288,33 +2288,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.6.tgz",
-      "integrity": "sha512-QMXPxWubWA3Sy1+BdvKSJLF4ZHIMaJFzpBQoksN1uxn3sLdoW3PpKRuLgokF5uQAS+08GjGzJOV132ktXkAnnQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.7.tgz",
+      "integrity": "sha512-WvRj1T0zSutcZMpZknNbpAQcKfGb//HClVEQm2VPpKcxGJGhMOwRNK5cA9sCAVDRBG10MsQ3WYIO7/ZBXNG6Vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.6.tgz",
-      "integrity": "sha512-l1MD3GmU6Xnt50NDRGc1NwROclNaAkQNlKydgcwiRRBwPEB8LjSGrcL2NzQ11YnG9snA2QpzFgZIK+jPgn54Og==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.7.tgz",
+      "integrity": "sha512-E0Cqq0o2SLioHijqKWem04jOM7B+fPVOGWkVuZRS9H4m6mdRGEU3M7Vf0hviOsKEiHn1Zy1NZXAi7bVoTQiT2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.7",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2322,37 +2322,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-t7YjOGVxPjfB5uIhHIWCyulDe56ikaJ8JKkfY3x//k8qsLUtpR663u43Hho/X/CbLiywpxk1ATQWzDXBbSxBkw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-+BAVWoUhOUqBzYyls7P6G0ijA+B2hC++l2/ev/HlJ5PoNRmiKZIDgkdIxD6s629uoJ5OtAB1P0inz54Zcww8/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-cosmwasm": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.6.tgz",
-      "integrity": "sha512-w1RS3OeHKoMN385t9kWFIrLyH57brCXbQbioMjaGY4DVrsFU3Xd3iqvm1je94yEBEbieJUc7+oxQDEh/AKtN4w==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.7.tgz",
+      "integrity": "sha512-EQuOIx2R2XjY5tLStFw4CDKN3pij6zHhdtXSbhBVmv79/3cLhI3QzaggntVT1tKnw+/wxocpdlMWSKH9NQprVQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.4.6"
+        "@wormhole-foundation/sdk-base": "3.4.7"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.6.tgz",
-      "integrity": "sha512-mqAc8ALw3P3gc57dPW2cIf8yniljOKU3rrrX89deucFvImE1pUHYG6b/z2paDXuV574nT11pXfsxpFYTMX+bTg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.7.tgz",
+      "integrity": "sha512-IQCwiMGB8ku9Vn9pr/ab7rhRm+hdbrO1pmRqKid5gwPe2Gd3k/DDoMYPiMskyhJ7TKZgQ6NpkwIYRqIcYRf5QA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2360,14 +2360,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.6.tgz",
-      "integrity": "sha512-KQirzy7Ay851uxPs4LfWppvFosUJ3TH5O91ONvdl9ClBrA+h8QDv44OYzJMae477zy1SJYzRhRbhHTxoMp6m8Q==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.7.tgz",
+      "integrity": "sha512-U+eSfucRL+8mDh+K6ApkWHPdURi09Gg1miw3CN8GLpI5nsmeEiE+kqr9nyIVWhDPmlQP8r+8Oo2cmtab774C6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
-        "@wormhole-foundation/sdk-evm-core": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-evm-core": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2375,13 +2375,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.6.tgz",
-      "integrity": "sha512-7M6ZjMJIiKkoUk/1dk2tJgM3rTbJxrKTNg9aHN2AhCQBxU/+7UMZslmuq8WlbnxKY/cc5ZS7WQA7rJVtWjZsUQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.7.tgz",
+      "integrity": "sha512-obNJ9lMHN3KYh412zHkpsWXjIyKAjV85cClgnVOCe5SyR5Q7iu7IISQodkyos764fnLu0viRitFR4yJCjs3Iqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2389,15 +2389,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.6.tgz",
-      "integrity": "sha512-xEStFlKEJCFwzNkyQ/oCn79sEqaAas95LC3OcWVyH0vr0GzJXf6OGL8Dq52LHUKcuUR8UtYcPWcFLIpA62pdcg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.7.tgz",
+      "integrity": "sha512-gXmnnZWRLlHE3mcAqNibbF/ECv1yin0b0aJR2SUWCJAc4h5UaW72CV3YQs7tv5YlDpEF0y+bJsoiKgZSmBFpdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
-        "@wormhole-foundation/sdk-evm-core": "3.4.6",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-evm-core": "3.4.7",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2405,14 +2405,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.6.tgz",
-      "integrity": "sha512-DmQmAWJ45H0ByAIgei3PgCpvFDSyIxJ6+kM4/7/4svt10m4SxBPYgqTXQrEbedN9gNhsiM77SZF0RJscQxbCLQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.7.tgz",
+      "integrity": "sha512-RibxNMmN+FVLGv65H6ZXqcb33/GH241tfmGCJtwS8tDqx5PRUm+jK8rD22KbsCAcMZTW4Gk4v4T2EsLCKpP1aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
-        "@wormhole-foundation/sdk-evm-core": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-evm-core": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2420,14 +2420,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-XAzlTvTxkUSYi5p35hwMqrNSlQ9yWTAhNkO9HKWJVsimR1kTBwk4M0Pj9k4iiYDqP//AXDdxQOgM70ZMKUzAHw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-6wkNa8LGYLXDEg3bStXnq84C3WDSwrI+y5FQwLAvBNPSwOb8il7AKMRFwexRoKs+ef+bQnJPXefnhbbYda6N0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-evm": "3.4.6",
-        "@wormhole-foundation/sdk-evm-core": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-evm-core": "3.4.7",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2435,16 +2435,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.6.tgz",
-      "integrity": "sha512-Css4Ob0J7LLwCVDRlYSxrH3ML4uNTakMF0foT2hk65hkjfq6rofuqocv5nqn+R0badmgQHctjxuQ+/NYiB5a9Q==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.7.tgz",
+      "integrity": "sha512-+gQPCmBccSXfR6ic/IvqwDBtOeDM7dAOK+OpuI5GxcRVn4gZvwoRBVuYmRAxlGwF5RgyqLwbHpHy+ktNBIjkYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
+        "@wormhole-foundation/sdk-connect": "3.4.7",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2452,123 +2452,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.6.tgz",
-      "integrity": "sha512-EhS4L1UeW6yRNuXQU9tX5857T9o2muBvdIKEie/YSnsZ+d3gg6/XWRum+a2WYc9kasPIte3ugOgs6hC7g9sqgg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.7.tgz",
+      "integrity": "sha512-pvhIg4fOAhLedQk0gwpmlaXkBYTFsMT/LhXHbuHwYhMzirncBNnpfyUc+J8nUlro+itkY0MT33ISWH35bHx+jA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-solana": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-solana": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.6.tgz",
-      "integrity": "sha512-BXqIEFVPU6VXGeXLbu6wOYCS1MmvAeobML+KnQetj5C9RWOIIG4jwwMyg8YXdqgHO+J/uxrfDZYCAtYfUNu/Ow==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.7.tgz",
+      "integrity": "sha512-up0D1F2iWizVBiF/MeCDTFmLaB2JvCswISp2qmKO9K2kQhI1LJodo7340O5NU5y6oFbOaxfTywSyHaUq3hgcjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-solana": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-solana": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.6.tgz",
-      "integrity": "sha512-CtU3QMrBHeJA28isvwf/DyC5FdmDb3hZSPGQ8yIhx8UKYFzSrD2TiVCE00+Tk1SgkMW1cSohMe+6msrj90dvoA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.7.tgz",
+      "integrity": "sha512-7i2KmDQg7djM2vgWSUoM/178QvMqnrYb+GI8SCkM+fU5ESNFtxPDh3Q5JWAcZAe5wj9Izh3Y+22D6f5VxhyivA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-solana": "3.4.6",
-        "@wormhole-foundation/sdk-solana-core": "3.4.6",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-solana": "3.4.7",
+        "@wormhole-foundation/sdk-solana-core": "3.4.7",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-hNw9eNpLUTjma75MYb2qTFkKmB+jUme9nr8oTgMVJ5x1zas7IXgd9Wd992XIaPCM36FYSivlezUBpFp14bHD6w==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-ukeWYjQDZlZfo+qHD1Cq8UGp8YV42qxlQ9pnAON9pnXmd5UFF4bCmQvtgxj7REz5i0tIfgr5IoReRZ19YcDTMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-solana": "3.4.6",
-        "@wormhole-foundation/sdk-solana-core": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-solana": "3.4.7",
+        "@wormhole-foundation/sdk-solana-core": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.6.tgz",
-      "integrity": "sha512-MzGSrYr8LFBzow2OChIKHmYsTiUeNI6CFOlx89r31ZsKdhF72zLnfoldegg5qQdlvT9X9+xoRcYHzRsOc1yawQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.7.tgz",
+      "integrity": "sha512-bpJXEjGvbelaZT9CmBf9kD0gNZILM3O3rGIm1LTvYgVVvjlUU84NCX+bwVPgsoHjc3Fd3ks6wlYHq9UCWcecng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.6.tgz",
-      "integrity": "sha512-Mgdg+vIJCq4lGQzbvEOrqkIiOg4GhZytIRLjuZ9vpgV5ZMiWbl9LpVFQ7i70yPv0mU/SFUy6VNkr2SECnDQsVA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.7.tgz",
+      "integrity": "sha512-kL9dpt5zxl1zVqmlR42fkmI2FBzhNbkwn4PqPfMUNNMJFamoW91FyMLmRByG5FThU2fpVd8m/BOO5u3tXY4JOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-sui": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-sui": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.6.tgz",
-      "integrity": "sha512-oNKm3dPW0BZ5xGheOOg+0lt2FHwLw76jsJ/SZXYll2W3RSToLJkdZ9XMPeMLI4aSVGHftrweRCF2pKj/ghwZMQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.7.tgz",
+      "integrity": "sha512-01DGJWhYqgOe8HN4rldHoEZEt0NONhZ8ODuFy7qASV5oGPOTSuTMqckLqByjXLX1bHwq2JSVs9B7dpflbW5Owg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-sui": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-sui": "3.4.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.6.tgz",
-      "integrity": "sha512-ohZVO3elXptPig39x0xM5dpyB46JZiFFEfn9hT5uK3nzNzyVEu/E1U0L5BpOp6rdkZDFEWgn2g552wrAUS5+HA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.7.tgz",
+      "integrity": "sha512-MdLT2MfLRIrkssgJum2MLFU6FYqgS+YcBTWD6mc57YUvuC5FmiFbSAEnknZyJLEzBmuyrVc21POStTOMcB0/BA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.6",
-        "@wormhole-foundation/sdk-sui": "3.4.6",
-        "@wormhole-foundation/sdk-sui-core": "3.4.6"
+        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-sui": "3.4.7",
+        "@wormhole-foundation/sdk-sui-core": "3.4.7"
       },
       "engines": {
         "node": ">=16"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.3.0",
+    "@types/node": "^24.3.1",
     "markdown-link-check": "^3.13.7",
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.4.6",
+    "@wormhole-foundation/sdk": "3.4.7",
     "sharp": "^0.34.3",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.4.5",
+    "@wormhole-foundation/sdk": "3.4.6",
     "sharp": "^0.34.3",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/src/chains/XRPLEVM.json
+++ b/scripts/src/chains/XRPLEVM.json
@@ -28,7 +28,7 @@
       "devnet": false
     },
     "ntt": {
-      "mainnet": false,
+      "mainnet": true,
       "testnet": true,
       "devnet": false
     },

--- a/scripts/src/generated/ntt-support.json
+++ b/scripts/src/generated/ntt-support.json
@@ -26,7 +26,8 @@
     "Linea",
     "Solana",
     "Sonic",
-    "Sui"
+    "Sui",
+    "XRPLEVM"
   ],
   "Testnet": [
     "Ethereum",


### PR DESCRIPTION
This pull request updates several dependencies in the `scripts/package-lock.json` file to their latest patch or minor versions. These updates help ensure compatibility, improve security, and provide access to new features and bug fixes.

Dependency updates:

* Core dependencies:
  - Upgraded `@wormhole-foundation/sdk` from `3.4.5` to `3.4.7`.
  - Upgraded `@babel/runtime` from `7.28.3` to `7.28.4`.
  - Upgraded `@metamask/utils` from `11.5.0` to `11.7.0`.
  - Upgraded `@mysten/sui` from `1.37.5` to `1.37.6`.
  - Updated `poseidon-lite` dependency from `^0.2.0` to `0.2.1`.

* Development dependencies:
  - Upgraded `@types/node` from `24.3.0` to `24.3.1`.

These changes are routine dependency maintenance and should not affect application logic but ensure the project uses the latest stable packages.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/617