### PR TITLE
bump axios and SDK version to 3.5.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.4.7",
+        "@wormhole-foundation/sdk": "3.5.0",
         "sharp": "^0.34.3",
         "swagger-markdown": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "^24.3.1",
+        "@types/node": "^24.5.0",
         "markdown-link-check": "^3.13.7",
         "typescript": "^5.9.2"
       }
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.16.1.tgz",
-      "integrity": "sha512-/6LWwZ/ZcC6/sI21s92cf3/8mgma6xRnBXtsF+708g2SX87WatJuXL8DjZsY1agCCnyw6bLVLtjKAfLQopNkxw==",
+      "version": "1.16.5",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.16.5.tgz",
+      "integrity": "sha512-eqXL3C/8JbP8u/4CHRyH7L/JJHNikZZFByxcFMqOxzNIxdzYnbueEDDk71lfYXGRFWqw+oU71kzu14hz9asxcQ==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -1024,9 +1024,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.10.tgz",
-      "integrity": "sha512-Tv0yM1JGSRzqtHp5fQlJ+B16Xej78WJrOqPrHC1H1MB9wr0NL3krAo86sm04IZI1RCq0Mv3hqCPPWqpZ6z+pRQ==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.11.tgz",
+      "integrity": "sha512-7mhT5cehnZvufPnYD72JYS+VtIGCVflT+RJ6G/0l0qwIjenBLGehK/qEfGeLAYdC2kH+VB6Ti19tlPcZ9ynmtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1147,12 +1147,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.10.tgz",
-      "integrity": "sha512-vdAKoMqJ7O3zEMaPzTcskDJfgS7zz6eSCQ7tJE7kIfStGEoK0aGJI7RdgWxfm4CApW4PKqb4u/LSmNkYHmMrww==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.11.tgz",
+      "integrity": "sha512-OK8o4952Ntm5n5ZTAyw2f6mVWCmUxShJcrtwZLFsGeB6kSuexvgaFDQhqSAIDeXIgtTfGbBwRtITaCk/9BANNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "1.16.10"
+        "@injectivelabs/ts-types": "1.16.11"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.10.tgz",
-      "integrity": "sha512-krRmlDzeKjJWZjIerVoIzN2ULgVVFvVlqbzOUfbv59KCJCU17e/6idadYlzBBxVa4r4Ybjs8A0fat7CjvVj0pw==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.11.tgz",
+      "integrity": "sha512-36q3kfE3MG6bVKL6tG7VSgs22VPgLYjx0Hwawd6qORfr/vFi6Gg9E9PUYQposAq0Mk4YL2QuUxjGJSkil72c0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -1208,17 +1208,17 @@
         "@cosmjs/proto-signing": "^0.33.0",
         "@cosmjs/stargate": "^0.33.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
-        "@injectivelabs/core-proto-ts": "1.16.1",
-        "@injectivelabs/exceptions": "1.16.10",
+        "@injectivelabs/core-proto-ts": "1.16.5",
+        "@injectivelabs/exceptions": "1.16.11",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.14",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "1.16.10",
+        "@injectivelabs/networks": "1.16.11",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "1.16.10",
-        "@injectivelabs/utils": "1.16.10",
+        "@injectivelabs/ts-types": "1.16.11",
+        "@injectivelabs/utils": "1.16.11",
         "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
@@ -1423,21 +1423,21 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.10.tgz",
-      "integrity": "sha512-ZkECbMz5zD2+pp3tHQzFnezuK1r23IgJc8SQ/Rbu+jogwGkQmHurQTLut0MfYFLKWaqfJPQhqndBs2Fm17NBAA==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.11.tgz",
+      "integrity": "sha512-vVJR6jJwPffvvOTkde+J0CBfZnQiWtTzhdNP9iKVAmDgYRys7MIwFmVZ63ELBmjMu2Lxxz7mORTZcYuVEH0B+Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.10.tgz",
-      "integrity": "sha512-0eOcKlQ9Uly9e3zgEmWlCA3uA2mPtmBH6qC94JQB/H2+dy+/3/OsksEuRTc5HJ8WIGKus/EtDbHygae/wkKz4w==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.11.tgz",
+      "integrity": "sha512-wEPo/IqWQIctNCw5vwC34TFYo2X5Z1dvuvXrT05+0PmbFHt4cDTiSo55qutyTdWEyV+1DKeoFGl9NVmYb8+y/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "1.16.10",
-        "@injectivelabs/networks": "1.16.10",
-        "@injectivelabs/ts-types": "1.16.10",
+        "@injectivelabs/exceptions": "1.16.11",
+        "@injectivelabs/networks": "1.16.11",
+        "@injectivelabs/ts-types": "1.16.11",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.7.0.tgz",
-      "integrity": "sha512-IamqpZF8Lr4WeXJ84fD+Sy+v1Zo05SYuMPHHBrZWpzVbnHAmXQpL4ckn9s5dfA+zylp3WGypaBPb6SBZdOhuNQ==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
+      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -1515,30 +1515,30 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.7.0.tgz",
-      "integrity": "sha512-8zE2Jzj2ai55RlVXx2pEMbbq+X3vB+uPGBvZr0F79IdTwuwcu4QdFG3PT/zHsytsvATkn+z0f2YDWhM5916u2A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.8.0.tgz",
+      "integrity": "sha512-bDoLN1nN+XPONsvpNyNyqYHndM3PKWS419GLeRnbLoWyNm4bnyD1X4luEpJLLDq400hBuXiCan4RWjofvyTUIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/utils": "0.1.1",
+        "@mysten/utils": "0.2.0",
         "@scure/base": "^1.2.6"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.37.6",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.6.tgz",
-      "integrity": "sha512-7ut5tWuXx9OIE+DQ2D5hd22UB8j8K4/F2Lx3R8Ej/JMwkm6cpgbF5FKNu0vYqehxiFEktMnq2YzzajxmlFHNPw==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.38.0.tgz",
+      "integrity": "sha512-tH6V4BJsYi5d97MOiLoOhyldrYxkm/cu8dYV52asqh1i88HrSVMbPAJ9sVoeWN2Ju+QsJ/Go4ldSjdCkaBCyJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.7.0",
-        "@mysten/utils": "0.1.1",
+        "@mysten/bcs": "1.8.0",
+        "@mysten/utils": "0.2.0",
         "@noble/curves": "^1.9.4",
         "@noble/hashes": "^1.8.0",
         "@scure/base": "^1.2.6",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "gql.tada": "^1.8.12",
+        "gql.tada": "^1.8.13",
         "graphql": "^16.11.0",
         "poseidon-lite": "0.2.1",
         "valibot": "^0.36.0"
@@ -1548,9 +1548,9 @@
       }
     },
     "node_modules/@mysten/utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.1.1.tgz",
-      "integrity": "sha512-jvhJC6/2la1QHltukQXzfyTZ+VVHxe187JjPx+mEXRUWyAo6jCSdioOQJIfaGu4K4i+37KeiydXRwV/bq/7UJQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.2.0.tgz",
+      "integrity": "sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.2.6"
@@ -1826,9 +1826,9 @@
       }
     },
     "node_modules/@solana/errors/node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2062,12 +2062,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
+      "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/pbkdf2": {
@@ -2114,52 +2114,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.4.7.tgz",
-      "integrity": "sha512-9yuyBtN/BESr8pB2BCLWsRd3fT1Ef6BZapoV7++CW/F2cqcXkmdBGJjhJTJilhpn4HJkYtnfdKAk5BP9Pzwolw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.5.0.tgz",
+      "integrity": "sha512-6noqsOA8JvycDec3SWwKE/Yb/fnZooHsuLWQHPttlaCcWFwTDZSf1o5MUlv7iqzMbAGmKhg/2E5g0NkGOEnBtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.7",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.7",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.4.7",
-        "@wormhole-foundation/sdk-aptos": "3.4.7",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.4.7",
-        "@wormhole-foundation/sdk-aptos-core": "3.4.7",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.4.7",
-        "@wormhole-foundation/sdk-base": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.4.7",
-        "@wormhole-foundation/sdk-definitions": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
-        "@wormhole-foundation/sdk-evm-cctp": "3.4.7",
-        "@wormhole-foundation/sdk-evm-core": "3.4.7",
-        "@wormhole-foundation/sdk-evm-portico": "3.4.7",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.4.7",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.7",
-        "@wormhole-foundation/sdk-solana": "3.4.7",
-        "@wormhole-foundation/sdk-solana-cctp": "3.4.7",
-        "@wormhole-foundation/sdk-solana-core": "3.4.7",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.4.7",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.7",
-        "@wormhole-foundation/sdk-sui": "3.4.7",
-        "@wormhole-foundation/sdk-sui-cctp": "3.4.7",
-        "@wormhole-foundation/sdk-sui-core": "3.4.7",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.4.7"
+        "@wormhole-foundation/sdk-algorand": "3.5.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.5.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.5.0",
+        "@wormhole-foundation/sdk-aptos": "3.5.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.5.0",
+        "@wormhole-foundation/sdk-aptos-core": "3.5.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.5.0",
+        "@wormhole-foundation/sdk-base": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.5.0",
+        "@wormhole-foundation/sdk-definitions": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
+        "@wormhole-foundation/sdk-evm-cctp": "3.5.0",
+        "@wormhole-foundation/sdk-evm-core": "3.5.0",
+        "@wormhole-foundation/sdk-evm-portico": "3.5.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.5.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.5.0",
+        "@wormhole-foundation/sdk-solana": "3.5.0",
+        "@wormhole-foundation/sdk-solana-cctp": "3.5.0",
+        "@wormhole-foundation/sdk-solana-core": "3.5.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.5.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.5.0",
+        "@wormhole-foundation/sdk-sui": "3.5.0",
+        "@wormhole-foundation/sdk-sui-cctp": "3.5.0",
+        "@wormhole-foundation/sdk-sui-core": "3.5.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.4.7.tgz",
-      "integrity": "sha512-FenOZxrL0dXwmggmViroJjvhNGGk5PqBHZh9zPyU7RRgdRJW7Gcc3MWvbggPJnpEqdMGCArwChdt7uj9y6TfUg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.5.0.tgz",
+      "integrity": "sha512-XBoHdm92wpuru+yYSV9tDCi9EOHgBd4C0ksBfyOR4+5c/8YAJDeJyD2AqwzxWuRtJMqdGVd576GdQK2QHy+HhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2167,89 +2167,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.4.7.tgz",
-      "integrity": "sha512-K6ajwBA2w2gWreDUAviQowaPjSFde8gO7m0Jq0Rr7j/Z/qLWIdAif5A2PFPWJJzuDtWkN01uoRDw+3LJFoAnZw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.5.0.tgz",
+      "integrity": "sha512-bXVLvbjFLbt5Gs9eDPKxmFOb2V5pE3S6jRWoN3ZCCbwp6JD8Hqz+5RAXyFZ4M/Jm2po0olObV9LnJ5e90IjMGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-algorand": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-nz9Msh5vFaoUfWg+kXyrf9deTG3mGT5CsqXloyvr023FzKCXfLwyNrmrqRbUmSUtZTk+0nk8Mm4SoI9+oxzT+A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-hylzTByJ5SHGFXzhBsG2hI4fXRiDP2iATJ/5L0etmUK6i+ZKIChQ75Tgh8z+DMHI5iM2am5A7E0ypv35sSov7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.4.7",
-        "@wormhole-foundation/sdk-algorand-core": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-algorand": "3.5.0",
+        "@wormhole-foundation/sdk-algorand-core": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.4.7.tgz",
-      "integrity": "sha512-kY+0sGL+UUneA+TDuHHBBYaD/gp9sdec6iCpKPXIqCk6PzIzbGTnDq0ZhJ8YXRLNY/enQ1RZUlHjvIr6rzz6cA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.5.0.tgz",
+      "integrity": "sha512-4e/mPpJ8tftujs4MTuhdct0BlQcjBGEMJ9hOzIgJ+XjEl+rt4GRcv76RJTyVT4mtXpE5UDAWXX8ovoZPR5FvjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.4.7.tgz",
-      "integrity": "sha512-G6pJtx12E1CHNRt9b8gD1tJNWZ/BGne5PN/0iWm9CQ60wEdzGEzIpAwYyJMatyrgidtoGwVB9xV4W26eKbmFFQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.5.0.tgz",
+      "integrity": "sha512-uBZFHZznYo0kdnV06cl9E9IiPZAJmGXYfZ7/lXieQL8Ggo6du6+s0ZX9nWR179Z1SNK+F6jjdBquzrdAsjC/vw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-aptos": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.4.7.tgz",
-      "integrity": "sha512-T50Od7BkpT/ASIBIX6XnUsndXWxnbbKPumtqb+/k85N0SPndwqmWZK35IEEsBIU7a0P3yDt/U47u4fqXjYUupQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.5.0.tgz",
+      "integrity": "sha512-fSIi8rHVbURfeBXZWiS2y2Bl8JbI95waTXvqvFQGKr4X6Y3a+nr7h4Mh+2fE9RXc3qCqWnEft+5Wx8wdXuTx4g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-aptos": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-R6rdD7B4v3hWT6ktUREaMGIypA5wFaS6WlPdF2hYriV0T9SGsHC+lwiL2Gm9Xyx0oMGweFSSnEPEAvB43b32ng==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-33MvfLlwSxxqTiBIgC+INcHtvHQsfMS6uTrftNDKrEWzqTFTPFz5uQerFNu+oUX0obebB4y7GR7uInelRfqQAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.4.7",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-aptos": "3.5.0",
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.4.7.tgz",
-      "integrity": "sha512-m4gYwE7O5/+p5e2tPLbcWrdncKAIOgaM+jC4p+yNfApA0wSOltYAGm0eCsc49mJdkpJsfwNvW+8Q5K45E3NmWQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.5.0.tgz",
+      "integrity": "sha512-/YS06rXKGI5Xd2VAO7pwASDVIOKaXSMMYo4rCErrqabyA1Z93chlQ5jg0SNWJP9OGozk8u7we8JLZzdI7f+cuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2257,13 +2257,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.4.7.tgz",
-      "integrity": "sha512-O9deBV7l46wK50yfhnWf8y9oI/UsFcdZIdnwISh/dmmxpfOymPSZpGI5YCPefhmAM4I450ALaXscjslWBvvU2w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.5.0.tgz",
+      "integrity": "sha512-5gDXJAactyyFIBRSiIxXpX3OMu0WXJI8JknFEO6YefPk249Ivsif0xil+e2SzVwLuRz5Mb2USfD9WHh5kx06ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.4.7",
-        "@wormhole-foundation/sdk-definitions": "3.4.7",
+        "@wormhole-foundation/sdk-base": "3.5.0",
+        "@wormhole-foundation/sdk-definitions": "3.5.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2271,16 +2271,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.4.7.tgz",
-      "integrity": "sha512-2+q131H5uWYSmHYiLPMS4i5rHQ/yIkQyeoQLehmBFtWKMWnJJ/93Va4b2uhwP8/e4bRtz2QR79eRPTiCSXiiDg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.5.0.tgz",
+      "integrity": "sha512-kC4CtA0ZUSfHZe0ajxbUl4hiteITwuRb5VGr9qlo5boXr2Ipid7V74eG8h8Z8xOTpAgeGSFycCGz+nHNPWQCow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2288,33 +2288,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.4.7.tgz",
-      "integrity": "sha512-WvRj1T0zSutcZMpZknNbpAQcKfGb//HClVEQm2VPpKcxGJGhMOwRNK5cA9sCAVDRBG10MsQ3WYIO7/ZBXNG6Vg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.5.0.tgz",
+      "integrity": "sha512-o5fiq9NpvL6DFoCUZD2fjLOeOQcEQwLjwaa1mt2OGca7LZLH5aOk2qeJT2mmotJhXzeaWexFb+UCXGxrKCJumQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.4.7.tgz",
-      "integrity": "sha512-E0Cqq0o2SLioHijqKWem04jOM7B+fPVOGWkVuZRS9H4m6mdRGEU3M7Vf0hviOsKEiHn1Zy1NZXAi7bVoTQiT2g==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.5.0.tgz",
+      "integrity": "sha512-ZM59auB3Wzfstw4Wc/GsAXzLrG73bPuHsKZwtVtYqcsLnnEk4rAzc1AOWc6r4ZoYGSP1y304pJEF9++gEHoGxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.5.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2322,37 +2322,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-+BAVWoUhOUqBzYyls7P6G0ijA+B2hC++l2/ev/HlJ5PoNRmiKZIDgkdIxD6s629uoJ5OtAB1P0inz54Zcww8/Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-6N+Hnz2EtpS6g+BY5CxQWIWFd6grZ9hfS1PcDXFNBDV/iiaSSEAle1Td1DZid0KeA1ygHiznvml3sndA8ETEpw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-cosmwasm": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.4.7.tgz",
-      "integrity": "sha512-EQuOIx2R2XjY5tLStFw4CDKN3pij6zHhdtXSbhBVmv79/3cLhI3QzaggntVT1tKnw+/wxocpdlMWSKH9NQprVQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.5.0.tgz",
+      "integrity": "sha512-QgeZc+b7E7/2Kg7e+vz5aNayRIfxD34I0XuX2CHMcLGVp2aJwHVQja1Po/QnKyvOvStkyldxcG+dWmIdeYef1A==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.4.7"
+        "@wormhole-foundation/sdk-base": "3.5.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.4.7.tgz",
-      "integrity": "sha512-IQCwiMGB8ku9Vn9pr/ab7rhRm+hdbrO1pmRqKid5gwPe2Gd3k/DDoMYPiMskyhJ7TKZgQ6NpkwIYRqIcYRf5QA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.5.0.tgz",
+      "integrity": "sha512-8J+OHB2Eaa7Qn+IPAQTxDBSuLBNnPqS1JJ9LPTBOAWMtrFiQfkxPuAvuBwwqMe5DjmTj963TswwVb+53R8Ah+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2360,14 +2360,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.4.7.tgz",
-      "integrity": "sha512-U+eSfucRL+8mDh+K6ApkWHPdURi09Gg1miw3CN8GLpI5nsmeEiE+kqr9nyIVWhDPmlQP8r+8Oo2cmtab774C6g==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.5.0.tgz",
+      "integrity": "sha512-oUzNaU78vNISl/u2j7w9NFnEemEp4/U7qa/kyOkN+uSAqhJ158/ECWPz+sc85rHPbWeNFSoVsyQXJGMN7O+6VQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
-        "@wormhole-foundation/sdk-evm-core": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
+        "@wormhole-foundation/sdk-evm-core": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2375,13 +2375,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.4.7.tgz",
-      "integrity": "sha512-obNJ9lMHN3KYh412zHkpsWXjIyKAjV85cClgnVOCe5SyR5Q7iu7IISQodkyos764fnLu0viRitFR4yJCjs3Iqg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.5.0.tgz",
+      "integrity": "sha512-tNzUR6vtoTiTJ6037PE+REl3WnN0T1MQJIximg1d15Ch+hP3VHf7QyAyZE26r7oV0IcYdwRk6Rs2yxMAUPFtBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2389,15 +2389,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.4.7.tgz",
-      "integrity": "sha512-gXmnnZWRLlHE3mcAqNibbF/ECv1yin0b0aJR2SUWCJAc4h5UaW72CV3YQs7tv5YlDpEF0y+bJsoiKgZSmBFpdQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.5.0.tgz",
+      "integrity": "sha512-MTQ2AGPpkguTjmZ46JklCgs+dltXizQ6w3plJ/YxAEuyjL20mZwkalrwvfag9O6zOqE462Z1+dXl1PTr2zbibg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
-        "@wormhole-foundation/sdk-evm-core": "3.4.7",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
+        "@wormhole-foundation/sdk-evm-core": "3.5.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2405,14 +2405,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.4.7.tgz",
-      "integrity": "sha512-RibxNMmN+FVLGv65H6ZXqcb33/GH241tfmGCJtwS8tDqx5PRUm+jK8rD22KbsCAcMZTW4Gk4v4T2EsLCKpP1aQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.5.0.tgz",
+      "integrity": "sha512-m+reN/eIPS6IIGxbL367bIGjPvBdlhbD6XiVXXys3YJRiRbLguc3i2AQzwFxe3VCXiPbBIkPK7QKyNDMJ0zQPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
-        "@wormhole-foundation/sdk-evm-core": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
+        "@wormhole-foundation/sdk-evm-core": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2420,14 +2420,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-6wkNa8LGYLXDEg3bStXnq84C3WDSwrI+y5FQwLAvBNPSwOb8il7AKMRFwexRoKs+ef+bQnJPXefnhbbYda6N0w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-RkE57TrVQAqo793prcfo7ESJtYE46slLcwGFyN2GF3wTla5jziKsi5UcpVv/NYQ7J6BmAfqAhjFk1egumEeHrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-evm": "3.4.7",
-        "@wormhole-foundation/sdk-evm-core": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-evm": "3.5.0",
+        "@wormhole-foundation/sdk-evm-core": "3.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2435,16 +2435,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.4.7.tgz",
-      "integrity": "sha512-+gQPCmBccSXfR6ic/IvqwDBtOeDM7dAOK+OpuI5GxcRVn4gZvwoRBVuYmRAxlGwF5RgyqLwbHpHy+ktNBIjkYw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.5.0.tgz",
+      "integrity": "sha512-S3KWc04TU5StRf2+OYIPXuNEMZLj3wHSZHRECLrmIairxetsq9JjqhXKham4tM4pwJ3NdW5GKJZ+0jZhVX6M8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
+        "@wormhole-foundation/sdk-connect": "3.5.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2452,123 +2452,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.4.7.tgz",
-      "integrity": "sha512-pvhIg4fOAhLedQk0gwpmlaXkBYTFsMT/LhXHbuHwYhMzirncBNnpfyUc+J8nUlro+itkY0MT33ISWH35bHx+jA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.5.0.tgz",
+      "integrity": "sha512-+W6FGodF5EuQxYoB1o+hIYNI+v7n8RxZrwvwTuMM9tue0/aDoggw38qXw6pP76lJhB4Ga+ArYKa5/MjPFkX/Yw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-solana": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-solana": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.4.7.tgz",
-      "integrity": "sha512-up0D1F2iWizVBiF/MeCDTFmLaB2JvCswISp2qmKO9K2kQhI1LJodo7340O5NU5y6oFbOaxfTywSyHaUq3hgcjg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.5.0.tgz",
+      "integrity": "sha512-61ugqnI9FEQZ6iIJAsXgR/4B2Trn4Lk93jZEg7LassTO73oanQ68KJn0v6TtvTyxUsXo5uEUOiWIdnDd/yLNmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-solana": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-solana": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.4.7.tgz",
-      "integrity": "sha512-7i2KmDQg7djM2vgWSUoM/178QvMqnrYb+GI8SCkM+fU5ESNFtxPDh3Q5JWAcZAe5wj9Izh3Y+22D6f5VxhyivA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.5.0.tgz",
+      "integrity": "sha512-plSMkVIKbfjRYaKHtKd3246WelNerRWG78VRNYZsSuQDwSXlAvkzfDodU06ZYl2SPlA9r1CjdE+3Slq5GqOB8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-solana": "3.4.7",
-        "@wormhole-foundation/sdk-solana-core": "3.4.7",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-solana": "3.5.0",
+        "@wormhole-foundation/sdk-solana-core": "3.5.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-ukeWYjQDZlZfo+qHD1Cq8UGp8YV42qxlQ9pnAON9pnXmd5UFF4bCmQvtgxj7REz5i0tIfgr5IoReRZ19YcDTMQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-UdReXAQS0hhbZTP3SHdtKYFecYklTSA1PnoBXQXkdIj91lnjJdh5jwxHw8tG7ew/vRk/6JWV2ez/QJ31h4EswA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-solana": "3.4.7",
-        "@wormhole-foundation/sdk-solana-core": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-solana": "3.5.0",
+        "@wormhole-foundation/sdk-solana-core": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.4.7.tgz",
-      "integrity": "sha512-bpJXEjGvbelaZT9CmBf9kD0gNZILM3O3rGIm1LTvYgVVvjlUU84NCX+bwVPgsoHjc3Fd3ks6wlYHq9UCWcecng==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.5.0.tgz",
+      "integrity": "sha512-Ftf7fW7yznEGi0cVDHWipmacE9RZ0SbKVji6P/7lRseAtnhbrIiMJfAjsnJ1VqLc/Kxs3rEP+iM/u8NrTgzArA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.4.7.tgz",
-      "integrity": "sha512-kL9dpt5zxl1zVqmlR42fkmI2FBzhNbkwn4PqPfMUNNMJFamoW91FyMLmRByG5FThU2fpVd8m/BOO5u3tXY4JOg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.5.0.tgz",
+      "integrity": "sha512-2nff7HlZ1JSsz/zCHXFC2k4DaKi1nLlFq335JWkwf8CGiA2uvYuFYqrk74XTWJ0oxmdMBPMnZ2fo4u971efivA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-sui": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-sui": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.4.7.tgz",
-      "integrity": "sha512-01DGJWhYqgOe8HN4rldHoEZEt0NONhZ8ODuFy7qASV5oGPOTSuTMqckLqByjXLX1bHwq2JSVs9B7dpflbW5Owg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.5.0.tgz",
+      "integrity": "sha512-WyHFzFfhpI0Pf8CQK2rvCD6FdFmGQzM8M/wjczbd+mc5eE4l3CXD83eZZlQJ27ioSvSm8IuqP40Qo2EMxpuaQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-sui": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-sui": "3.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.4.7.tgz",
-      "integrity": "sha512-MdLT2MfLRIrkssgJum2MLFU6FYqgS+YcBTWD6mc57YUvuC5FmiFbSAEnknZyJLEzBmuyrVc21POStTOMcB0/BA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.5.0.tgz",
+      "integrity": "sha512-TdQQYvVxvh/sjudf6IWJ0CTm531jW05ibAh93qyD9zImXtMR7KIBLb8fkJR+NkZJ+rfESlDze7t3sZHXK20MFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.4.7",
-        "@wormhole-foundation/sdk-sui": "3.4.7",
-        "@wormhole-foundation/sdk-sui-core": "3.4.7"
+        "@wormhole-foundation/sdk-connect": "3.5.0",
+        "@wormhole-foundation/sdk-sui": "3.5.0",
+        "@wormhole-foundation/sdk-sui-core": "3.5.0"
       },
       "engines": {
         "node": ">=16"
@@ -2757,9 +2757,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6144,9 +6144,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/utf-8-validate": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.3.1",
+    "@types/node": "^24.5.0",
     "markdown-link-check": "^3.13.7",
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.4.7",
+    "@wormhole-foundation/sdk": "3.5.0",
     "sharp": "^0.34.3",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/src/chains/HyperEVM.json
+++ b/scripts/src/chains/HyperEVM.json
@@ -26,6 +26,11 @@
       "mainnet": true,
       "testnet": false,
       "devnet": false
+    },
+    "cctp": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
     }
   }
 }

--- a/scripts/src/generated/cctp-support.json
+++ b/scripts/src/generated/cctp-support.json
@@ -13,7 +13,8 @@
     "Sonic",
     "Linea",
     "Worldchain",
-    "Seievm"
+    "Seievm",
+    "HyperEVM"
   ],
   "Testnet": [
     "Sepolia",
@@ -29,6 +30,7 @@
     "Sonic",
     "Linea",
     "Seievm",
+    "HyperEVM",
     "Ethereum",
     "Optimism",
     "Arbitrum",


### PR DESCRIPTION
This PR started out as just a bump to the axios version (in the `package-lock.json`), but ended up that an SDK version was released like 30 min ago. So this also bumps the SDK version.

Goes with https://github.com/wormhole-foundation/wormhole-docs/pull/623