### PR TITLE
Martinh/executor tables

### DIFF
--- a/scripts/src/chains/ArbitrumSepolia.json
+++ b/scripts/src/chains/ArbitrumSepolia.json
@@ -37,11 +37,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/BaseSepolia.json
+++ b/scripts/src/chains/BaseSepolia.json
@@ -38,11 +38,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Converge.json
+++ b/scripts/src/chains/Converge.json
@@ -15,11 +15,6 @@
       "mainnet": false,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Fogo.json
+++ b/scripts/src/chains/Fogo.json
@@ -15,11 +15,6 @@
       "mainnet": false,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   },
   "explorer": [

--- a/scripts/src/chains/HyperEVM.json
+++ b/scripts/src/chains/HyperEVM.json
@@ -31,11 +31,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Mezo.json
+++ b/scripts/src/chains/Mezo.json
@@ -32,11 +32,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Monad.json
+++ b/scripts/src/chains/Monad.json
@@ -32,11 +32,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/OptimismSepolia.json
+++ b/scripts/src/chains/OptimismSepolia.json
@@ -42,11 +42,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Plume.json
+++ b/scripts/src/chains/Plume.json
@@ -32,11 +32,6 @@
       "testnet": true,
       "devnet": false
     },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
-    },
     "cctp": {
       "mainnet": true,
       "testnet": false,

--- a/scripts/src/chains/Sonic.json
+++ b/scripts/src/chains/Sonic.json
@@ -26,16 +26,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "ntt": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/Worldchain.json
+++ b/scripts/src/chains/Worldchain.json
@@ -45,11 +45,6 @@
       "mainnet": true,
       "testnet": false,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/XRPLEVM.json
+++ b/scripts/src/chains/XRPLEVM.json
@@ -36,11 +36,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/aptos.json
+++ b/scripts/src/chains/aptos.json
@@ -51,11 +51,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/arbitrum.json
+++ b/scripts/src/chains/arbitrum.json
@@ -52,11 +52,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/avalanche.json
+++ b/scripts/src/chains/avalanche.json
@@ -60,11 +60,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/base.json
+++ b/scripts/src/chains/base.json
@@ -52,11 +52,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/berachain.json
+++ b/scripts/src/chains/berachain.json
@@ -41,11 +41,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/bsc.json
+++ b/scripts/src/chains/bsc.json
@@ -48,11 +48,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/celo.json
+++ b/scripts/src/chains/celo.json
@@ -48,11 +48,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/ethereum.json
+++ b/scripts/src/chains/ethereum.json
@@ -55,11 +55,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/linea.json
+++ b/scripts/src/chains/linea.json
@@ -44,11 +44,6 @@
       "mainnet": true,
       "testnet": false,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/moonbeam.json
+++ b/scripts/src/chains/moonbeam.json
@@ -48,11 +48,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/optimism.json
+++ b/scripts/src/chains/optimism.json
@@ -52,11 +52,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/polygon.json
+++ b/scripts/src/chains/polygon.json
@@ -52,11 +52,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/scroll.json
+++ b/scripts/src/chains/scroll.json
@@ -49,11 +49,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/seievm.json
+++ b/scripts/src/chains/seievm.json
@@ -32,11 +32,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/sepolia.json
+++ b/scripts/src/chains/sepolia.json
@@ -36,11 +36,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": true
-    },
-    "executor": {
-      "mainnet": false,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/solana.json
+++ b/scripts/src/chains/solana.json
@@ -54,11 +54,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/sui.json
+++ b/scripts/src/chains/sui.json
@@ -51,11 +51,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": true,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/unichain.json
+++ b/scripts/src/chains/unichain.json
@@ -56,11 +56,6 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
-    },
-    "executor": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
     }
   }
 }

--- a/scripts/src/config.ts
+++ b/scripts/src/config.ts
@@ -72,12 +72,6 @@ function getChainDetails(chainName: string): ExtraDetails {
       products.tokenBridge[net.toLowerCase() as keyof ProductSupport] = true;
     }
 
-    // Executor
-    if (contracts.executor) {
-      if (!products.executor) products.executor = { mainnet: false, testnet: false, devnet: false };
-      products.executor[net.toLowerCase() as keyof ProductSupport] = true;
-    }
-
     // CCTP
     const effectiveChainName = chainNameOverrides[chainName] || chainName;
     const isCctpSupported = (cctpSupport[net] || []).includes(effectiveChainName);

--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -156,10 +156,10 @@ export function generateAllContractsTable(chains: types.DocChain[], module: stri
           module === 'cctp'
             ? network.contracts?.cctp?.wormhole
             : module === 'tokenBridgeRelayer'
-            ? (network.contracts as any)?.executorTokenBridge?.relayer ?? network.contracts?.tokenBridgeRelayer
+            ? network.contracts?.executorTokenBridge?.relayer ?? network.contracts?.tokenBridgeRelayer
             : module === 'tokenBridgeRelayerWithReferrer'
-            ? (network.contracts as any)?.executorTokenBridge?.relayerWithReferrer
-            : (network.contracts as any)?.[module];
+            ? network.contracts?.executorTokenBridge?.relayerWithReferrer
+            : network.contracts?.[module];
 
         if (!address) {
           let newAddress: Partial<types.ChainDetails> | undefined;

--- a/scripts/src/details.ts
+++ b/scripts/src/details.ts
@@ -152,7 +152,14 @@ export function generateAllContractsTable(chains: types.DocChain[], module: stri
   const generateRows = (networks: types.ChainDetails[], chainType: string): string[] => {
     return networks
       .map((network) => {
-        let address = module === 'cctp' ? network.contracts?.[module]?.wormhole : network.contracts?.[module];
+        let address =
+          module === 'cctp'
+            ? network.contracts?.cctp?.wormhole
+            : module === 'tokenBridgeRelayer'
+            ? (network.contracts as any)?.executorTokenBridge?.relayer ?? network.contracts?.tokenBridgeRelayer
+            : module === 'tokenBridgeRelayerWithReferrer'
+            ? (network.contracts as any)?.executorTokenBridge?.relayerWithReferrer
+            : (network.contracts as any)?.[module];
 
         if (!address) {
           let newAddress: Partial<types.ChainDetails> | undefined;
@@ -193,20 +200,19 @@ export function generateAllContractsTable(chains: types.DocChain[], module: stri
 
   const devNetTableBody = orderedChains.flatMap((chain) => generateRows(chain.devnets || [], 'devnet'));
 
-  // Combine everything into the final table
-  return `
-=== "Mainnet"
+  // Render each tab
+  const mainnetHtml = formatHTMLTable(buildHTMLTable(tableHeader, mainNetTableBody.join('')));
+  const testnetHtml = formatHTMLTable(buildHTMLTable(tableHeader, testNetTableBody.join('')));
+  const devnetHtml = devNetTableBody.length > 0 ? formatHTMLTable(buildHTMLTable(tableHeader, devNetTableBody.join(''))) : '';
 
-    ${formatHTMLTable(buildHTMLTable(tableHeader, mainNetTableBody.join('')))}
+  // Assemble tabs; only include Devnet if it has rows
+  const parts: string[] = [`=== "Mainnet"\n\n    ${mainnetHtml}`, `=== "Testnet"\n\n    ${testnetHtml}`];
 
-=== "Testnet"
+  if (devnetHtml) {
+    parts.push(`=== "Devnet"\n\n    ${devnetHtml}`);
+  }
 
-    ${formatHTMLTable(buildHTMLTable(tableHeader, testNetTableBody.join('')))}
-
-=== "Devnet"
-
-    ${formatHTMLTable(buildHTMLTable(tableHeader, devNetTableBody.join('')))}
-  `;
+  return parts.join('\n\n');
 }
 
 export function generateSupportedNetworksTable(dc: types.DocChain[]): string {

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -99,9 +99,18 @@ async function overwriteGenerated(tag: string, content: string) {
     'CCTP_ADDRESS',
     generateAllContractsTable(chains, 'cctp')
   );
+  // Executors
   await overwriteGenerated(
     'EXECUTOR_ADDRESS',
     generateAllContractsTable(chains, 'executor')
+  );
+  await overwriteGenerated(
+    'WTT_EXECUTOR_ADDRESS',
+    generateAllContractsTable(chains, 'tokenBridgeRelayer')
+  );
+  await overwriteGenerated(
+    'WTT_EXECUTOR_WITH_REFERRER_ADDRESS',
+    generateAllContractsTable(chains, 'tokenBridgeRelayerWithReferrer')
   );
 
   // Consistency levels


### PR DESCRIPTION
This pull request removes the `executor` configuration block from multiple chain JSON files in the `scripts/src/chains` directory. The change streamlines the configuration files by eliminating the `executor` property, which previously specified network availability for different environments (mainnet, testnet, devnet) across various chains.

This update helps keep the chain configuration files concise and reduces potential confusion or redundancy related to the `executor` property.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/642