### PR TITLE
Update SDK to the latest version

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "3.8.3",
+        "@wormhole-foundation/sdk": "3.8.5",
         "sharp": "^0.34.4",
         "swagger-markdown": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "^24.6.0",
+        "@types/node": "^24.6.2",
         "markdown-link-check": "^3.13.7",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -2514,9 +2514,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.0.tgz",
-      "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.13.0"
@@ -2566,52 +2566,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.8.3.tgz",
-      "integrity": "sha512-hqUWAxHgo7qbFqOSsIXD9KIt2/WpJG+Wq5ZG6AIRcYzvJBJ+pKviW8ztoera9X4b3QWVwdMadg1TSKJPMsflLw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.8.5.tgz",
+      "integrity": "sha512-F6gm4ZsnnTvNGfG7b4T/aLIsYWwPTQzlenZ4tJ57++BuTP0DviKzMPgSUJOHk4ReDcwcvXZJpP3xLcviQYJJnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.8.3",
-        "@wormhole-foundation/sdk-algorand-core": "3.8.3",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.8.3",
-        "@wormhole-foundation/sdk-aptos": "3.8.3",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.8.3",
-        "@wormhole-foundation/sdk-aptos-core": "3.8.3",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.8.3",
-        "@wormhole-foundation/sdk-base": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.8.3",
-        "@wormhole-foundation/sdk-definitions": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
-        "@wormhole-foundation/sdk-evm-cctp": "3.8.3",
-        "@wormhole-foundation/sdk-evm-core": "3.8.3",
-        "@wormhole-foundation/sdk-evm-portico": "3.8.3",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.8.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.8.3",
-        "@wormhole-foundation/sdk-solana": "3.8.3",
-        "@wormhole-foundation/sdk-solana-cctp": "3.8.3",
-        "@wormhole-foundation/sdk-solana-core": "3.8.3",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.8.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.8.3",
-        "@wormhole-foundation/sdk-sui": "3.8.3",
-        "@wormhole-foundation/sdk-sui-cctp": "3.8.3",
-        "@wormhole-foundation/sdk-sui-core": "3.8.3",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.8.3"
+        "@wormhole-foundation/sdk-algorand": "3.8.5",
+        "@wormhole-foundation/sdk-algorand-core": "3.8.5",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.8.5",
+        "@wormhole-foundation/sdk-aptos": "3.8.5",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.8.5",
+        "@wormhole-foundation/sdk-aptos-core": "3.8.5",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.8.5",
+        "@wormhole-foundation/sdk-base": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.8.5",
+        "@wormhole-foundation/sdk-definitions": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
+        "@wormhole-foundation/sdk-evm-cctp": "3.8.5",
+        "@wormhole-foundation/sdk-evm-core": "3.8.5",
+        "@wormhole-foundation/sdk-evm-portico": "3.8.5",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.8.5",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.8.5",
+        "@wormhole-foundation/sdk-solana": "3.8.5",
+        "@wormhole-foundation/sdk-solana-cctp": "3.8.5",
+        "@wormhole-foundation/sdk-solana-core": "3.8.5",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.8.5",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.8.5",
+        "@wormhole-foundation/sdk-sui": "3.8.5",
+        "@wormhole-foundation/sdk-sui-cctp": "3.8.5",
+        "@wormhole-foundation/sdk-sui-core": "3.8.5",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.8.3.tgz",
-      "integrity": "sha512-dY+ZMVlJxJQ3yof1I5WES/oSE6FIQ8laU5NvsUJsK0mt48Phi9hxME6r7yjeTFxBlJDqkCpoAx6VAqHYodWaUg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.8.5.tgz",
+      "integrity": "sha512-GZkzvTj/HJOnhRT0M95ME47yJjHs4IuvKpGYImFMOWF65xlbyLYDncvRXczchqhMKmkKivPw387hQph4WeQ01w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2619,89 +2619,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.8.3.tgz",
-      "integrity": "sha512-ChwfVF6sRBGYpCv5tBgG5lENEAw5sJ46T0lyKjiAa3Zel7ojLIxYCxGLRsYyZRPT3oBXq2PRv2lEUHgmV7V0+w==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.8.5.tgz",
+      "integrity": "sha512-DgYub2nks3FfcV7CkC0T9FDJ51n+m0yJ7/0NYsbp/MhjYaFh/IAklVBZfSMTitmQc5G7+BdTZkeQS/HwlAD/nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-algorand": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-XQgx8Z4PL9+uYHjmtIMvpwdlNPmm4Px+68MFjEDgU5chs1d7uxjMjZgF3+rHLCnj0TSHbNwFiPTLSmzzBYwylw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-W/tA13nWC10emmuaalVR0PTYQPYk3yxAkaOznx3Sllgd2mo1vEY6gHnpc4EKumYfVMS3fCZ+Jf5aqzNxI7yz1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.8.3",
-        "@wormhole-foundation/sdk-algorand-core": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-algorand": "3.8.5",
+        "@wormhole-foundation/sdk-algorand-core": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.8.3.tgz",
-      "integrity": "sha512-ZiLkllu6Waj5hGnI7SM9tyhksqxvVvokniJ5nOOF8FH9WH5jfExqFoO5Ios+dElvI2DKumJssuB8y+06DneqRw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.8.5.tgz",
+      "integrity": "sha512-nORCUAsCD5gpvisHsuhTd77SVIo4U98TOvw2rH/eQGLjW8QH5MwgHDq0VftVoX0wU4mkYlfTsNHHFH6Oapcd3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.8.3.tgz",
-      "integrity": "sha512-lKJm8sgXcLGbwqA3oFHYF6NWQ98wh6V0agXps1EI4AxxgI0D9TWoqUqGB7Th+3UOrBWVeGqmiGdPllirZWZHFg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.8.5.tgz",
+      "integrity": "sha512-lO6ZJHLt44Ni7aynfVonjoq6RBijWm+UF4knwgWDok2fkemHSj5SSvu+zGvdQkIlNPzR6HLBtuSoLD75U8YjKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-aptos": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.8.3.tgz",
-      "integrity": "sha512-HuYZQ4KYBasXLUnBPOOea9keGqJcv4fQCqZodpdN8Y8oZgcVWJ92jwCXMsUdT5zmZf7QpCoAVmXVRUdyXZctAA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.8.5.tgz",
+      "integrity": "sha512-URMsnoPPRzuQrdA6DwOjQ6cQFcJKl7P77xJK7PuaqqC6ne575v3B/n9kDfnV836ReahaZ+wUPKsGOKwpm+MJcA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-aptos": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-p0Gx44zpI91HdAhILXL++iOrnwc5wiFotpv2v3Ai4UIQL8T9mdhjqEiqxeaeZTDV8TRMdpwuz150ZazRJqWOcA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-5wF+h6ZfB+c4EI6W8Dpp8/SZkwZw26jK56BK4mgDtYv4g/6xIYkMCmnWNUWaox29pz7WmtGjQNvDY84Xa9uZjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.8.3",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-aptos": "3.8.5",
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.8.3.tgz",
-      "integrity": "sha512-3uq7Z1Oa1caURsYHE1fkvCpp/UjXZppfJ0OHFiV1VzD8zQkJH120nHanuBJn554vo+9+zaPv7pwMwO8iztmmOg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.8.5.tgz",
+      "integrity": "sha512-54qlg8Ulmfi4Vh97QEx3lh3qYN+z4rPiU0ETX2H3wJnS/LIRA98n+ilm0sSaCZAfoZgm9iC4EnmDXoBWhmIl1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2709,13 +2709,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.8.3.tgz",
-      "integrity": "sha512-Ho6PelbsUwbF1E29J+PlyJ3R8lXx0CRfM8qLMCdN3rf5zGYDQ09ztlZQGK3/t48dM3TA4ZgcCTKvETdcVQmhmw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.8.5.tgz",
+      "integrity": "sha512-BZW0kj3eKSWFg2V/wXM7Q+WwXqU7eaTrHLIWxcw6nddGP1lY+scVa+g1Ox7e9zyyfKeguCJTSBL0hqJ0YF7tYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.8.3",
-        "@wormhole-foundation/sdk-definitions": "3.8.3",
+        "@wormhole-foundation/sdk-base": "3.8.5",
+        "@wormhole-foundation/sdk-definitions": "3.8.5",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2723,16 +2723,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.8.3.tgz",
-      "integrity": "sha512-Qkx5s4K3lv2KOa8Z1JeHvW9T30nX04w4IZVvZcWY87x7SSvFERTO05lkr2hTy5KnmYxzP3kSQ5Nfkfuv9iSE+Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.8.5.tgz",
+      "integrity": "sha512-tKawM02b3UgZp7+7cKdU4w7yudCE31Z9ZN7g0oQrVAPEgM2Ok4Yu3DmKomRv3GcqyoEcUdRLTt8yHlUYpIJjBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2740,33 +2740,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.8.3.tgz",
-      "integrity": "sha512-3zPA7UCieNB9Jv53pofon3FvTFyptV3rqCQI2+X6evtUnxJr0ziLNRVdCoGrViTHasofnrWgjRzwKQDbWWcJqA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.8.5.tgz",
+      "integrity": "sha512-UPHWDGmrjOlQD6pE9Ld+o8jOXlruhynfwbsHv1yhVM++rZ16MEXXM2U4MKmHtco+O3aqX0vAtJT0VcrJzSoNKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.8.3.tgz",
-      "integrity": "sha512-gow8Rip9J0kHhktNhNQIpu/Fk9fXN08KDF1zQi4qiSiIaoDx6KSWaYIuJETztVgMxVpMZFuGWdsKr0si9r5fAg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.8.5.tgz",
+      "integrity": "sha512-PAetTWQQoMNQNuMXyaT9mFOL70agnxmRarDiiCP+Gq+ByZ7Xg9/+rtt6IBPTdmHnmLAhOw4XunomCMGh9h3b5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.8.5",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2774,37 +2774,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-aJOh/4xpiRSN3x0u8/fY0Vdy9+cQzUgRc1xGwnw9TRt620x62Oe7D/tJTiv/F9ONoPt7Xso3R8eSCk5rWojtbQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-Hbeoj+y8i9edepkfopt3FauXYQGSPCvH59VyNtwhAieGeMdvdzgWdVd+awqOx+JP2AV0xyoquTTt6dZMn4Ye/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-cosmwasm": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-cosmwasm": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.8.3.tgz",
-      "integrity": "sha512-uBAbxUCzolQXUDWDM+0Bi0r1fWgWw522ZHs9WEgoftya4Gsh4kEGpaHrkOpHhPVSAoHVtHkmJwE26IZf19pZYg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.8.5.tgz",
+      "integrity": "sha512-wkCwIEmGaTnCiZbpsgXA0738A/APS0ji9d77AmQ3T5lw96hcPznvT2WpPyR0LMk10LOJMoRbPiqhgmas/GtZwg==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.8.3"
+        "@wormhole-foundation/sdk-base": "3.8.5"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.8.3.tgz",
-      "integrity": "sha512-FIPZE9qn1q/HKP6oL2QAhcf6QmQxBMqbRJwPKCr7ob0WAIKjh5uySnix3wcfA/wCbzft30ZU+H/1jLcCcQiFbA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.8.5.tgz",
+      "integrity": "sha512-A+a5kPfHDQg8hCXCfIcHkiaiYdUapkR1fFAFUZIXnIrqsB6q4ANpgZKjWKAz+70H2W4UNUFzqvR40FkJDlEDrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2812,14 +2812,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.8.3.tgz",
-      "integrity": "sha512-st2XxPAlZlzwe9dcnzV+lhUzRImhdWCdtxBy9oo/eRQTt4MzbeZ7Fgjzyq3ZO5y821Jb+qKKtCX2sfE2WGn+ZQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.8.5.tgz",
+      "integrity": "sha512-sEq7vSiCoNsa/OT2rwXWUdvHl8EyDx4Uc9DRSYZPVfq4Suh5JpiF44ZY6JOwXTi4v1irA+2koAC1vAOvOqh4tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
-        "@wormhole-foundation/sdk-evm-core": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
+        "@wormhole-foundation/sdk-evm-core": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2827,13 +2827,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.8.3.tgz",
-      "integrity": "sha512-xeIZdEGvlghKqCpckBEc5s3F34cplxK9MmuU0EWnoDaiIgVhAobuAQ5h/3AwPGnvYmirNqmTAM+PWerhVJ6+JQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.8.5.tgz",
+      "integrity": "sha512-pl3Z+SD+B1uwlM9glOJ6A7KYi7/2OWjYns0wNmCA/s2GM/GV9yGRyCxwMCQX5QrGuTPXiIe9wSj/1EoreehmeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2841,15 +2841,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.8.3.tgz",
-      "integrity": "sha512-UIStjUtJmJ9mdf6BtXJOKJ2UtfYB8AM03iijwDxMUubE3G1GNTuzWxc1JgCzchs4FmyEUO3PQ2xRazgXpStpVQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.8.5.tgz",
+      "integrity": "sha512-G8TzzuR2DN1xC98z3xvjzgRjsWJkSD7QL/e+A+ILljBhyVv9bnbEB5mJGlAe9sOad6icWmU5w8TJh3Vfu9ZMig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
-        "@wormhole-foundation/sdk-evm-core": "3.8.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
+        "@wormhole-foundation/sdk-evm-core": "3.8.5",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2857,14 +2857,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.8.3.tgz",
-      "integrity": "sha512-8G2IFu+rEPWYAyboH5HRVEnS5w4O0Z3cAA+Av1uY0TTdXQ34ErvadUCzh0YFiX27kU7916Si4jE2wHB/zWyVSQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.8.5.tgz",
+      "integrity": "sha512-dyj46Q8ieOY45GCykUO3ZsLdZ1Yc0gtDFmLISjtrcUI7DmoIwWeqM4DGLPAfNXdkmMS/vRkIFqnBQWQRQGD2wQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
-        "@wormhole-foundation/sdk-evm-core": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
+        "@wormhole-foundation/sdk-evm-core": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2872,14 +2872,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-Kau5twg6bXnCl6jSniVf1f7BuN0QIndHWuq0rtpig0oDcOeg7NGP8T6UjWDuIPBukG7zKyp9dWBHzytUeF7C/g==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-L0pnJmHnRfxpmLTJhJM6nO3oFbmQSjJGo6rQal9zfXDuz0fnHYLP98opQjpHwwi/ZIOFiqwzRaqjx8A/lR5b5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-evm": "3.8.3",
-        "@wormhole-foundation/sdk-evm-core": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-evm": "3.8.5",
+        "@wormhole-foundation/sdk-evm-core": "3.8.5",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2887,16 +2887,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.8.3.tgz",
-      "integrity": "sha512-DIMsMc68LorTzULCO9hjcE6p/UYCLvFKhVdKWT1XzBt0KILBcvKPgkX0UNCRHGOlpNkzT4Nip/6ql8LFSTGj0A==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.8.5.tgz",
+      "integrity": "sha512-mUT9I6Ogluy1NYfBTSoyZeN1xl+iMnc5U9K8KC++gFACwcPq39QYIvyl9M1RG6WN5hhEZP5FlLVugXizA803Ww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
+        "@wormhole-foundation/sdk-connect": "3.8.5",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2904,123 +2904,123 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.8.3.tgz",
-      "integrity": "sha512-ZjMdt+Z8A+TSg+DjxPRxwTywTYw9iIRMai9SsGMQNZ7Qz51GL+fWCtD6BMcTyxk6WwflOxr3MGLNa+YTySJW3w==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.8.5.tgz",
+      "integrity": "sha512-tov0XiMG6v2ZBR9liakxxTR1AnNrTNmOSpQEVEsKMa4ez/Xzwh1BS4OpIxYjeHr6yDDIDa0+1CIO+XtbGSMz/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-solana": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-solana": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.8.3.tgz",
-      "integrity": "sha512-aKpxrCpjPhJibyLEIkncaKbAD+cgIkxSxXfyJgQxvCABQUYYGKkHdPc2taHqInFPKByRJDGBOBCngvK6n4rbgA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.8.5.tgz",
+      "integrity": "sha512-xHDdzsQtZs66Sc0d88XPsHVlgh72KYvl0TRqe2bt2sLwUi39jhO3Rru80VvbGsAGplPa/MauuDeKAib6uS7egA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-solana": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-solana": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.8.3.tgz",
-      "integrity": "sha512-pprm89UDKKNCcEs3UYrWN71OL5GevFcnIQy2T+njp8aoM28+iHFFt1GQJTQzJJw2rhykivIXubmGHU0He3sGMg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.8.5.tgz",
+      "integrity": "sha512-Ff7oq9A67wS0hyYdsqaaV8YDUFjgvp1pP/TbtIGghcE+t18PAgwpe3+sf+nOK2vKJnmkfLu2HsOT7AkU/KXsRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-solana": "3.8.3",
-        "@wormhole-foundation/sdk-solana-core": "3.8.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-solana": "3.8.5",
+        "@wormhole-foundation/sdk-solana-core": "3.8.5",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-rJzh8URfpGTLZ+aVWJyB5RNXp1rKdM7f8QanFhCpRqKm3iLvuWNyoSd7ku88O3zHJH99CKWyZGbFqDM9e45k+Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-eHMv5i9bNjnA4e8QZPxDOMpvnqMtRSx1IOVhmPjK/VO1puI/4ufRgl1VhIEFL4pE+LPNNEk/1f7w1iuBVWiYOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-solana": "3.8.3",
-        "@wormhole-foundation/sdk-solana-core": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-solana": "3.8.5",
+        "@wormhole-foundation/sdk-solana-core": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.8.3.tgz",
-      "integrity": "sha512-JQ6JSB30CePRPvQc68I0O+HyRrJITF03R6ittROPfIWe+i8O8XFIw6Yhi06Z20nOJrp5ZKlIel7tS8fGJufxlQ==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.8.5.tgz",
+      "integrity": "sha512-OUu3wH4Bex7HT79Y5pT+FpdJdNBoltgMZD94iMkDTnBjIYVb9pkJQ7wE9rduGuWOycYDxtuxunOuREkm+CrzFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.8.3.tgz",
-      "integrity": "sha512-WggrviVOiz0hyeKr0nwoH8nn6B9UJstEGo31ayeU5WK82sHoLgg0LzJ31T1fmAFWWQE9lmHJPn8WSzkUhITCBA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.8.5.tgz",
+      "integrity": "sha512-9N+353eLH8F+u8Ghg3kpjc0vIMkBH/9YdiSKYXZaPmNVm1VCSnKI117+UcrCknIIi0qzfwC5p6JNF9p1bsuBDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-sui": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-sui": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.8.3.tgz",
-      "integrity": "sha512-/c/s2pFFzrZ6XpgvAoOMXYedpEXsWbUu1cyp/s03hU2jlSG+zFBc9mG/FggDyJS3h2ETmX7rseAHRzSxRyFZxg==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.8.5.tgz",
+      "integrity": "sha512-6HyX5Q5v08NM5DzmVHaPYNOu4ohVKrHW0z0Nf7eLOqxfpHB295Ra87PTPl23G2vw/46YOf0DDtGJthiRhzN+lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-sui": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-sui": "3.8.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.8.3.tgz",
-      "integrity": "sha512-3vseUsnItE9WoXYoVyC7heE3+rn/BtwJ7KcgW6GF/9y/v7flG3BD8pSQheWAoH75wCAXjFJfn6JVs77BXCQj5g==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.8.5.tgz",
+      "integrity": "sha512-Sg58waEDc10LlP83JrkkEEcPLdaITDqwdV3YMjIf7LChi9TTCAQ/8K20sWegVe+uZEcsOEBAdA6qksWj02LYfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "3.8.3",
-        "@wormhole-foundation/sdk-sui": "3.8.3",
-        "@wormhole-foundation/sdk-sui-core": "3.8.3"
+        "@wormhole-foundation/sdk-connect": "3.8.5",
+        "@wormhole-foundation/sdk-sui": "3.8.5",
+        "@wormhole-foundation/sdk-sui-core": "3.8.5"
       },
       "engines": {
         "node": ">=16"
@@ -3186,24 +3186,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/async-generator-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-generator-function/-/async-generator-function-1.0.0.tgz",
-      "integrity": "sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4566,29 +4548,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/generator-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.0.tgz",
-      "integrity": "sha512-xPypGGincdfyl/AiSGa7GjXLkvld9V7GjZlowup9SHIJnQnHLFiLODCd/DqKOp0PBagbHJ68r1KJI9Mut7m4sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/get-intrinsic": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
-      "integrity": "sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
-        "async-function": "^1.0.0",
-        "async-generator-function": "^1.0.0",
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "generator-function": "^2.0.0",
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
@@ -6670,9 +6640,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,13 +13,13 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^24.6.0",
+    "@types/node": "^24.6.2",
     "markdown-link-check": "^3.13.7",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "3.8.3",
+    "@wormhole-foundation/sdk": "3.8.5",
     "sharp": "^0.34.4",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/src/chains/Sonic.json
+++ b/scripts/src/chains/Sonic.json
@@ -27,11 +27,6 @@
       "testnet": true,
       "devnet": false
     },
-    "ntt": {
-      "mainnet": true,
-      "testnet": false,
-      "devnet": false
-    },
     "executor": {
       "mainnet": true,
       "testnet": false,

--- a/scripts/src/chains/evmos.json
+++ b/scripts/src/chains/evmos.json
@@ -1,24 +1,24 @@
 {
-  "homepage": "https://evmos.org/",
-  "title": "Evmos",
-  "mainnet": {
-    "name": "Mainnet",
-    "id": "evmos_9001-2"
-  },
-  "testnet": {
-    "name": "Testnet",
-    "id": "evmos_9000-4"
-  },
-  "explorer": [
-    {
-      "url": "https://www.mintscan.io/evmos"
-    }
-  ],
-  "devDocs": "https://docs.evmos.org/",
-  "faucet": {
-    "url": "https://faucet.evmos.dev/",
-    "token": "TEVMOS",
-    "description": "Official Evmos Faucet"
-  },
-  "products": {}
+	"homepage": "https://evmos.org/",
+	"title": "Evmos",
+	"mainnet": {
+		"name": "Mainnet",
+		"id": "evmos_9001-2"
+	},
+	"testnet": {
+		"name": "Testnet",
+		"id": "evmos_9000-4"
+	},
+	"explorer": [
+		{
+			"url": "https://www.mintscan.io/evmos"
+		}
+	],
+	"devDocs": "https://docs.evmos.org/",
+	"faucet": {
+		"url": "",
+		"token": "TEVMOS",
+		"description": "N/A"
+	},
+	"products": {}
 }


### PR DESCRIPTION
This pull request updates dependencies in `scripts/package.json` and modifies the chain configuration in `scripts/src/chains/Sonic.json`. The main changes are focused on keeping packages up to date and cleaning up unused configuration.

**Dependency updates:**

* Upgraded `@types/node` from `^24.6.0` to `^24.6.2` to get the latest type definitions.
* Upgraded `typescript` from `^5.9.2` to `^5.9.3` for improved TypeScript support.
* Upgraded `@wormhole-foundation/sdk` from `3.8.3` to `3.8.5` for bug fixes and new features.

**Chain configuration cleanup:**

* Removed the `ntt` configuration block from `scripts/src/chains/Sonic.json`, likely because it is no longer needed or supported.

Related to: https://github.com/wormhole-foundation/wormhole-docs/pull/644