### PR TITLE
Martinh/update sdk and ntt repo version

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -10,12 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@wormhole-foundation/sdk": "4.7.4",
-        "axios": "^1.13.2",
+        "axios": "^1.13.3",
         "sharp": "^0.34.5",
         "swagger-markdown": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "^25.0.8",
+        "@types/node": "^25.0.10",
         "markdown-link-check": "^3.14.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
@@ -2263,9 +2263,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
-      "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2927,9 +2927,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
+      "integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "4.9.0",
-        "axios": "^1.13.3",
+        "@wormhole-foundation/sdk": "4.9.1",
+        "axios": "^1.13.4",
         "sharp": "^0.34.5",
         "swagger-markdown": "^3.0.0"
       },
@@ -2297,54 +2297,54 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.9.0.tgz",
-      "integrity": "sha512-5uOd2YdDDG1KB1ttTkgkJcMtGUJwIDZ6CGExn5eMHI27f60cD1MQSJCCUoH7UbWYqJkeLhNX8WvagsSnTrRoQQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.9.1.tgz",
+      "integrity": "sha512-/5nv3ub7WGUzLJErwBk3kqjqWEA9htNiCaEmMwL9OZpYYlfZ/5B8L7AKaHWAmhyzmaL4kpyh5o69f+/DNlCqSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.9.0",
-        "@wormhole-foundation/sdk-algorand-core": "4.9.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.9.0",
-        "@wormhole-foundation/sdk-aptos": "4.9.0",
-        "@wormhole-foundation/sdk-aptos-cctp": "4.9.0",
-        "@wormhole-foundation/sdk-aptos-core": "4.9.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.9.0",
-        "@wormhole-foundation/sdk-base": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.9.0",
-        "@wormhole-foundation/sdk-definitions": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
-        "@wormhole-foundation/sdk-evm-cctp": "4.9.0",
-        "@wormhole-foundation/sdk-evm-core": "4.9.0",
-        "@wormhole-foundation/sdk-evm-portico": "4.9.0",
-        "@wormhole-foundation/sdk-evm-tbtc": "4.9.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.0",
-        "@wormhole-foundation/sdk-solana": "4.9.0",
-        "@wormhole-foundation/sdk-solana-cctp": "4.9.0",
-        "@wormhole-foundation/sdk-solana-core": "4.9.0",
-        "@wormhole-foundation/sdk-solana-tbtc": "4.9.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.0",
-        "@wormhole-foundation/sdk-stacks": "4.9.0",
-        "@wormhole-foundation/sdk-stacks-core": "4.9.0",
-        "@wormhole-foundation/sdk-sui": "4.9.0",
-        "@wormhole-foundation/sdk-sui-cctp": "4.9.0",
-        "@wormhole-foundation/sdk-sui-core": "4.9.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "4.9.0"
+        "@wormhole-foundation/sdk-algorand": "4.9.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.9.1",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.9.1",
+        "@wormhole-foundation/sdk-aptos": "4.9.1",
+        "@wormhole-foundation/sdk-aptos-cctp": "4.9.1",
+        "@wormhole-foundation/sdk-aptos-core": "4.9.1",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.9.1",
+        "@wormhole-foundation/sdk-base": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.9.1",
+        "@wormhole-foundation/sdk-definitions": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
+        "@wormhole-foundation/sdk-evm-cctp": "4.9.1",
+        "@wormhole-foundation/sdk-evm-core": "4.9.1",
+        "@wormhole-foundation/sdk-evm-portico": "4.9.1",
+        "@wormhole-foundation/sdk-evm-tbtc": "4.9.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.1",
+        "@wormhole-foundation/sdk-solana": "4.9.1",
+        "@wormhole-foundation/sdk-solana-cctp": "4.9.1",
+        "@wormhole-foundation/sdk-solana-core": "4.9.1",
+        "@wormhole-foundation/sdk-solana-tbtc": "4.9.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.1",
+        "@wormhole-foundation/sdk-stacks": "4.9.1",
+        "@wormhole-foundation/sdk-stacks-core": "4.9.1",
+        "@wormhole-foundation/sdk-sui": "4.9.1",
+        "@wormhole-foundation/sdk-sui-cctp": "4.9.1",
+        "@wormhole-foundation/sdk-sui-core": "4.9.1",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.9.0.tgz",
-      "integrity": "sha512-c9fDj2muwWrEWXqDexwIJa4DmfpXUuTzOlFPIOJ4miCYXWs3YoFEx3BECt4/r/q67X4G/W+fog4W0PJZ8lVWcA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.9.1.tgz",
+      "integrity": "sha512-/HEZ5YE1jJi5XF7hIssWeHuO8/MBnojQpCY0oSAvVJqMwRj/hNTU2nzeNLCrT3KDIigItgFy8nrcqwuERQMMgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2352,89 +2352,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.9.0.tgz",
-      "integrity": "sha512-lh9cW3D91pmC+DrRXfKZ5DCGH85TokBQnyxWAeMrK5l3jdk6j7Iq+zrbgAkPxoqYWE3ewNQkRLg+Fo+qLL2yVA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.9.1.tgz",
+      "integrity": "sha512-L3C2Y1PXUfeRRxOmCJd4ATS7yNwlDDtZt4uXan0wP9eEWQDyntXRRTiRs5FlVX24x6jsWKyQu9nYy2AyE3Vw/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-algorand": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-JJMaNO1vVM0zcY2XnDSrCkgsDReLaiRtqFHKnOzw+tEsvrXrqVgRchOEEt+Yv3mPeKmKo7LGjnVaSTaLjCJMNA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-wj8pHjfXlXNSJ3ztLS0rhBGq3lOKaS21lISnkTd3auPNrzOhGBj/Epob6Hj/UPQFYgb+w0XpnGp198MimqcMaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.9.0",
-        "@wormhole-foundation/sdk-algorand-core": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-algorand": "4.9.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.9.0.tgz",
-      "integrity": "sha512-h3luSO0c1xI6AN8HKrpyMEyjOIPc5zqpBWVL2izdc5NUZaQkFTcJEuVM3h/berpJMQJ85E1uE1JKOCNjykjHXw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.9.1.tgz",
+      "integrity": "sha512-j+wg0Sk8d27j88tHOLSTWdEBstZQy1CsWr4/9hBYMH1qgJLGsYvYy/YBXhSHxGkqmCQj9HPN7rzt3l+4Rjxxqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.9.0.tgz",
-      "integrity": "sha512-SkbQx/UPkJ4JWLTKkBDCCm+/DClW1aA5kX8BycLFByxLX/++vxf05PwGqcwNED/IIcZ7JnLxtCgU/6bfnfXNmw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.9.1.tgz",
+      "integrity": "sha512-vtfbTthCVn4+bCTv27lGMJ8PW76dEl7YPsAHRgN2/rVyS+L3b7q6yMCBKYZG8UuZr9jwfbanqLl7giqvT+IzBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-aptos": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.9.0.tgz",
-      "integrity": "sha512-wfxXUNkBVy475KR/5zOLrq50cl7xyC3HKEGtHdcaeKSqOZFyf8WYARIxuy9CiBktjBuqfWNrCuiXXwV7NjU4Ag==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.9.1.tgz",
+      "integrity": "sha512-6TgnlqQ+T6fMrNVmTZ+kj3zQfQqc6OuBlbsXg8UkFDbVV9zeGt4f99Okf7h5BRytKdV+/DNlTaox+UHriHwL2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-aptos": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-Baag10sfCXTnYvmhFo3gnTU7Pclkl+EXUHR4xXE4CNnxIGwxEnGkGPa7xZx7u1tSGarNpk5EcidSPKqcuyzd5g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-z20IxKMCeVKaRBD5YNU/P5VoWKBaQrOyKygMwWibqvxudy2DUckunGwkET5EF8NeLAIL2tCjGa8aFU++k9Opqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.9.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-aptos": "4.9.1",
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.9.0.tgz",
-      "integrity": "sha512-tZ8m8NnMkRuS1uciWbU4VJ74UNXwpWHWeJ07QY7bOapd12hkPiKxb2ZFJETBTjCXTE4/cGmqFi3/rsLLsVPKIA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.9.1.tgz",
+      "integrity": "sha512-bT8E6rp6ApucUs77X5YS2FYlj1QN71YIa1cTikxtf97BZXgd0L1OaYt1oQygiX/79J+EVVz7PFHJDZAowsq7VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2442,13 +2442,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.9.0.tgz",
-      "integrity": "sha512-luBXnv3QOiNqH8g+yTPcksU7xfgc0PMIIrGAbI3YW52KJXW524nzxWkxRa0ckVEfi0P/H/RJTPUwoW6xbCySCg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.9.1.tgz",
+      "integrity": "sha512-XMoreVwDkvRF0qHxPxh1savuOFddAr/2btoaPHcawKrQIcfrdEqiytvgCdOEk3UJvwwte2j9C8fwyWUd2/+LWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "4.9.0",
-        "@wormhole-foundation/sdk-definitions": "4.9.0",
+        "@wormhole-foundation/sdk-base": "4.9.1",
+        "@wormhole-foundation/sdk-definitions": "4.9.1",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2456,16 +2456,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.9.0.tgz",
-      "integrity": "sha512-VMfUhoixl1c+84wXE7+Wh/R/TB7jFCQJXWqYiWLia27gN2c6v8zKLuu6BzpBwcsjCmBA0xMEr2UDmFHwIXf8aA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.9.1.tgz",
+      "integrity": "sha512-ly96k7m31JKegsXs74Hx+CCdVlbjvhhfj3Lz2NqP4dKZFCJ78GCXWC0yR1k8nUBAjVr/BFDYzNpxS8lFmgZ9Qw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2473,33 +2473,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.9.0.tgz",
-      "integrity": "sha512-MH8tQypwgBQSR/Xa0vkq42Ca1gMJOXV0dNgTuHPu2ebtcNxoeUYKnj7Rt5tSLl3k85H/q3zHlZti4VKl1HoEfg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.9.1.tgz",
+      "integrity": "sha512-mxltYdsSdDKNdAsyhRq77fJWWq4uFKBhBqF5Uup1qRFwuWlqsrsPQXbDvGKiIMVEMY/6whBYZK/9eK5YxWIzRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.9.0.tgz",
-      "integrity": "sha512-hgG01A8TdZRxXQbayVDTmBwtxdF0p4MbzpDQn9Wds11P1AI3/RQfhgAv+3BdL3xDs9WOT1NAq6X1RDeoJXgewA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.9.1.tgz",
+      "integrity": "sha512-NllXBC8iarQXPwa5ylq+9JFy+1byDtbVYQdKaoHMODOxDJ3gmFuMvviw0KUU9F2dKgE2kvpITv9IRmAJsX9fAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2507,37 +2507,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-WhYleGQ1zFc+BU3HCX7a8UOGa08LaI+ky+1v4WAa9KPV/TfiSvx36cu57m6rxNQMOdP5YtWYr8nMNoDq7DMw8Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-/tBWDhHaNGVsS5V1CxDrrLnKUU1JoAUISU5+FWb4Gv24N7/YU8EXxiNsa2lDecOPHwmQOA0KaI39M0FoH0Uu3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.9.0.tgz",
-      "integrity": "sha512-R5WfVat/IEB2ECJBv2c41CkIBmZoLnotafDdOJUfzXGPTIPVwweB7fjGQiMie/8pudUSDsVq4m1o6d/Q9xLx+Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.9.1.tgz",
+      "integrity": "sha512-cWiWToO0VcRBaKfW3jCPDyZBxhXaFzOBjwiv6rr9qVCJviAeoqUKgArVBUk412qpw8OdsmvvJEY7DxFj7Ci9jw==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "4.9.0"
+        "@wormhole-foundation/sdk-base": "4.9.1"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.9.0.tgz",
-      "integrity": "sha512-7X2MU2Oi8gA9p50mrNTyQxOMUcsZqLSMYl3RYgrGGYYK/GtEEy+Y/+46lUYwpY8ziZHdkWaUDXiRD7+lCQmrRA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.9.1.tgz",
+      "integrity": "sha512-WzLJA+UJzOIGCjuHfuhmpDw2kznDEqq2qDBusBLmyqz6qYAgsJrCQhH5h8XyLzMqhnuc2JC0O7w8Dn4d1EPONw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2545,14 +2545,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.9.0.tgz",
-      "integrity": "sha512-dZ0lKrhQiBSvANeFPSJWi8LFj/7I8W6xNNa0GYf9igsf1mcU3oCIBdRfEEchrmydACq9WE0OQ39Ye5Da73pYJQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.9.1.tgz",
+      "integrity": "sha512-+giUQLNVMZEc84E+ANne5TyUsHGbssA6nIIdHJOMZ2A14a/+Tw8h1lZCtyTOzy6DeSl0jAJYNcgrtJ9YfX4nHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
-        "@wormhole-foundation/sdk-evm-core": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
+        "@wormhole-foundation/sdk-evm-core": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2560,13 +2560,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.9.0.tgz",
-      "integrity": "sha512-Xk7c1fLy0cJGD6sNqPCAVxCSxbWHKqnczIIgTs6pzRQCmIYpGkOfFoa2oZ2OSfsN0bpa2+dD8QN6fIkLd70IRQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.9.1.tgz",
+      "integrity": "sha512-kzcIMibRICjxG5yPI1kMozXQjLsxUXasEh1lMVEqe/XPOg1iQQyjEcLxIuYcd3fDk4FDnUrzr1iQh7OyGNWyyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2574,15 +2574,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.9.0.tgz",
-      "integrity": "sha512-uQcfBoCxkvBOjTbIw4oRN6v8mYxOBLwtD/rA4pyQpabelU2u0gIlXxFxnUPUMqWIFOx5f3z06Kx8jBEz3hBCKQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.9.1.tgz",
+      "integrity": "sha512-4Deff3DmSs+U4eYwB0uiz6B4aj+4mZqAcVI03qoJtZeOAUT+X9Y7ilfSBccynMpooVGkR5m2Ip7u4tNkyqg2Ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
-        "@wormhole-foundation/sdk-evm-core": "4.9.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
+        "@wormhole-foundation/sdk-evm-core": "4.9.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2590,14 +2590,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.9.0.tgz",
-      "integrity": "sha512-2ElkqPLkxcQGLLDMw1lMRYtM0lgRCdCtaYkxwLDcyMuWGqL8/m0hGIrhIYk5+BMYnYw7zB4jlED23Bwlo7IOmQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.9.1.tgz",
+      "integrity": "sha512-Ngl6J5Bg6XNNFlZIu+jDHfHVXF6YSRa4xeT3e2nGqzHaSj76HD1KSPWnnE3B0VrxANmAa0BvlG9095hV5nHDDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
-        "@wormhole-foundation/sdk-evm-core": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
+        "@wormhole-foundation/sdk-evm-core": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2605,14 +2605,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-gN5zIWAhcAOo7pCT6K6tbVR+4CUMVN1piZQf7NgSgRtvTKNIhb/DNcFVEsTxdf6sggjh4qVI59HQ3jQyJPNy8g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-bxRAWLrIxXLYl4FwrkO8fv7gUk7vnQAOTxjEHAtljsuWc4mM2cjTm/n6bA/cfl+AQCXiMbASM3tLBmCf6DZFrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-evm": "4.9.0",
-        "@wormhole-foundation/sdk-evm-core": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-evm": "4.9.1",
+        "@wormhole-foundation/sdk-evm-core": "4.9.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2620,16 +2620,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.9.0.tgz",
-      "integrity": "sha512-H542TcPDY7jW4SlzRXKMVXRmZQauWmFp3dTg4DRVUhvzG24OQ4dlvTydT2MuLd2fSKZA1yWVFCCxtmFN1Nas9A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.9.1.tgz",
+      "integrity": "sha512-zidQX/SCy6bZIsnFdGGDziL82QAckshbrRW+nRc0ucL8mC5gsh13OWfg2AS1CEyF17XJfQ1J0WwTWIzNpay8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.1",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2637,150 +2637,150 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.9.0.tgz",
-      "integrity": "sha512-DrYXbDnmKI3j8vfUB8nKMZx1jflGZhTnJYZSy/tTJQE2XB7PrRFMIeZLuTnnNbqPYLPZHGVp7QVD6p1gsISX4A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.9.1.tgz",
+      "integrity": "sha512-W0AqwbguSXPwM/kjHkuIvCtyUf+FAy/4hIYEGqnydYef6cI+TVGcyAdSEDVxZ1sCQr32N1a59p67puLGAFtVdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-solana": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-solana": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.9.0.tgz",
-      "integrity": "sha512-cJtdWcVJVT3C7OgNKjHWboWRPv7b4Vpa4E3qAgYb069z72QM1XLi3goORIGf6sZ1c0KDe5qOFh0wqOR9QVRPMQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.9.1.tgz",
+      "integrity": "sha512-TGRb46y0SLlJDivRw1YUObnI9d1jsKtSE7jbQFYLrp11ijih5KAovBnBiBgbOTlpNCUeyRWZxcscUXo3TMc/kg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-solana": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-solana": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.9.0.tgz",
-      "integrity": "sha512-gVoUc+Irg1JPH83rBkHNt1bt1aRyCdgpA1tQj4KDLMnikn7TdZSN2rMGKCKCnpERrsCQQWg1YqmFPUoi7h8UMg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.9.1.tgz",
+      "integrity": "sha512-8FoR2bEts+5u9L1Sk7IdKRPHFuYZu2iRTEtkVs0xYaYsA6l4Mg9fI5jg1op6sYcoxFHIxMjUB+bBZnAq5e154g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-solana": "4.9.0",
-        "@wormhole-foundation/sdk-solana-core": "4.9.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-solana": "4.9.1",
+        "@wormhole-foundation/sdk-solana-core": "4.9.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-/YpLwLBCyq0Xo8HBuzN+6R7NdC2XxkIU/A/eyfhlLTM347lE62+DFPHFEoZHF1jANKSRDwpxYFWgsblWanvn1w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-e9p25rljxbE6RWjuHEkMjXjWaHJHKa7QLgqQPvOvSuOGPQAsFmFDe8D6Xs8Owj6iCwPa3hEQHYkudaMtSpuKpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-solana": "4.9.0",
-        "@wormhole-foundation/sdk-solana-core": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-solana": "4.9.1",
+        "@wormhole-foundation/sdk-solana-core": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.9.0.tgz",
-      "integrity": "sha512-JwfGAcmxcjpLFFDUTRt2m2WDjG1B66x4dwdOITMzQkYcvVANRJHTAKmUd9FXBGfMieBQ2y/dlnlR0aVZCak7RQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.9.1.tgz",
+      "integrity": "sha512-qDLuBHold86d0x583yNai39+Y6tOC3s4Awe2/xvdaonLt/lCxNY5SUPjjq43kKF+Ug8/0G68s5kUpJ66DRuYtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stacks/network": "^7.0.2",
         "@stacks/transactions": "^7.1.0",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.9.0.tgz",
-      "integrity": "sha512-kKKm572BV/ktsKaP+Qk5fBlKQCuFJuliJ6vQysRSHxDaw38bGZvjz0MeXFgUELuL3QxlWF50e9cNwJ31kMvy7A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.9.1.tgz",
+      "integrity": "sha512-sbtl9pA+kgjJz7Cp7ti5VEis2uA7B51se+Svx3Uosuci9/c7BdXcQxql27Fzd2eWM//teLLOeaePLxDiinDUow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-stacks": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-stacks": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.9.0.tgz",
-      "integrity": "sha512-V3+ab/25S3U5YMLvchruw+cfQOE3PuLD22pru4emlUAxsTmOCu6mho15EXy4BJvnAcnX0KU2vaR2wP/hzLZNhw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.9.1.tgz",
+      "integrity": "sha512-8w7+FTnM9+1r03YWAhX7/N9ofj37B7MJzSZdj4a8Jq/Sv6bYXiQUNchteKPCkCweMnsNVjSja1C1vZ6xYZ4uXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.9.0.tgz",
-      "integrity": "sha512-tX52xP0vfsvRx0O1wUeCMfk+acsRNu0lHXyPu415VXeSoMgiePyiHrcE9BoDRcFIrh1wvkQcfWrTrXTH1wOm4w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.9.1.tgz",
+      "integrity": "sha512-I/PrbA7xWSQWFz0iX/0GSKpyS+mmkviD/Q1/adMpG+rqQsjxtZuy9cZIMMzS1KJiHayPBstB9dzhGMKhxkkR4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-sui": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-sui": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.9.0.tgz",
-      "integrity": "sha512-pflzuzqf6LuNDaqj4wt5mF+APKjzehwOyVNZZ+Vn2Az/hOHLvE4mhdIyf4nHVWP7K5y0kCp0Vmr5sBK7+8zpdg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.9.1.tgz",
+      "integrity": "sha512-/x6cuvKBMYXInHym3fGcr8SaX4LwgsmbD7D3IEcJqUO5QKmFY2eTE20Ex+9D/lfQoo/Ek8atfaAjmrBQ4a7b/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-sui": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-sui": "4.9.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.9.0.tgz",
-      "integrity": "sha512-vznzH5vs6PSXIowo35CvVZrPA6e8e9XYQPxYqxABvJicpV7HPy7vj8WN96pGYwq6TxGYhADXXUT/DoNwth7Y9Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.9.1.tgz",
+      "integrity": "sha512-mdD/yUrreax7PZTimH1bD8jiK+szobRegU4b1tPWGSugvvfbGp1CYAVM1PuTq3zjRBops5KGYF9kM+5aeCGTnA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.9.0",
-        "@wormhole-foundation/sdk-sui": "4.9.0",
-        "@wormhole-foundation/sdk-sui-core": "4.9.0"
+        "@wormhole-foundation/sdk-connect": "4.9.1",
+        "@wormhole-foundation/sdk-sui": "4.9.1",
+        "@wormhole-foundation/sdk-sui-core": "4.9.1"
       },
       "engines": {
         "node": ">=16"
@@ -2927,9 +2927,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
-      "integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3939,9 +3939,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "4.7.4",
+        "@wormhole-foundation/sdk": "4.9.0",
         "axios": "^1.13.3",
         "sharp": "^0.34.5",
         "swagger-markdown": "^3.0.0"
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.17.4.tgz",
-      "integrity": "sha512-bkdBp+alz9zaLH39lmgIumNleC3gyPT6nOaIhVNLe+6V7a8pRvuPwMK1UFjnn3QNECxWl5eQE/WZfHpeiuqBVA==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.17.6.tgz",
+      "integrity": "sha512-QVgaQMhaM4/2MOOth32B6ZwhtSQCVkwwFzWpIFJU8UsAkripoXXtjxseHSDJ+yzIFHElcf4afzWiWpsZWsiv2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1434,18 +1434,18 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.17.4.tgz",
-      "integrity": "sha512-dL+48Cg0JkPkPVCC0sLGj1xGjyr37PI0gqsjFviAIGpk9DcCNPg20/qOLaAjWq9ge0wiv15Z3EcJlS7UwOwfsQ==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.17.6.tgz",
+      "integrity": "sha512-KorCgskim/bYZ89BklbJJXSL0i0NeOO8gTbXT6aKyZKxWESyYmccaM96NEBji2HVa03hADc9/Ghd/JOWQnfEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "1.17.4"
+        "@injectivelabs/ts-types": "1.17.6"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts-v2": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/olp-proto-ts-v2/-/olp-proto-ts-v2-1.17.3.tgz",
-      "integrity": "sha512-ZWRkwxh+KKypAqXGUuLosRl/4bmShk892PLqxJBcRrIEPKq8xVrJT9iMVEtdkf1WOstIhG1+kmqlcSaL0UcR3A==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/olp-proto-ts-v2/-/olp-proto-ts-v2-1.17.6.tgz",
+      "integrity": "sha512-3jTAyj342TXVe8qsVcDzAUnH5vAbqoHy5jqTUxHvJtfDaJ+X0uvN6d/yj60CxmrDOyKrn6pFx0prZ6J3Tl8S6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1454,9 +1454,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.17.4.tgz",
-      "integrity": "sha512-CVH7SUGXU6xbb6cFHYItcCrC5btUKf+FFH5/ppwH5cudAjIbB82lNSV32TO5Q51hD8quLtXyWYe+YFD0isjs+Q==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.17.6.tgz",
+      "integrity": "sha512-9TWzaRytSeP5anlPGw64y1M9M8IDbJbK/lOLsVyPC9ftAuX6/jN4X6fLT5f8GlDIzV8S1wRqTy2Xu4F5/wwmcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.33.0",
@@ -1464,16 +1464,16 @@
         "@cosmjs/stargate": "0.33.0",
         "@injectivelabs/abacus-proto-ts-v2": "1.17.4",
         "@injectivelabs/core-proto-ts-v2": "1.17.3",
-        "@injectivelabs/exceptions": "1.17.4",
+        "@injectivelabs/exceptions": "1.17.6",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts-v2": "1.17.6",
         "@injectivelabs/mito-proto-ts-v2": "1.17.3",
-        "@injectivelabs/networks": "1.17.4",
-        "@injectivelabs/olp-proto-ts-v2": "1.17.3",
-        "@injectivelabs/ts-types": "1.17.4",
-        "@injectivelabs/utils": "1.17.4",
+        "@injectivelabs/networks": "1.17.6",
+        "@injectivelabs/olp-proto-ts-v2": "1.17.6",
+        "@injectivelabs/ts-types": "1.17.6",
+        "@injectivelabs/utils": "1.17.6",
         "@noble/curves": "^1.9.0",
         "@noble/hashes": "^1.8.0",
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1625,20 +1625,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.17.4.tgz",
-      "integrity": "sha512-SUPRISD/ja3tZfq2j1cf6gss9emioyW+Wk5n793IiInWCVgzp26jrNZYYkZKaolgwJpe65tfpBQwfMwrOzaBLg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.17.6.tgz",
+      "integrity": "sha512-/cQGcSNkVIpYqP9SwC4DEKzrkf0QicpTKUEILVRAvfOkkGBiZzUwywCVJkJAp/89ubI/5mBQyhfIBmjUjDA+9Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.17.4.tgz",
-      "integrity": "sha512-rkLBW6PM8tdh62ixO/lope8BcxGT7CP7A31TqpUejw3R18g0WCvitFwW+9yhu3cL8MOH0ijbOuvLheAdSAIfXQ==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.17.6.tgz",
+      "integrity": "sha512-FDa0F2FNZEblXKYzJn2/9aMNs0vsOAo+5HGEPj7lurlovbxvDw766SNswaMKkCsB74AXyqxilXRjpGmnGHfU3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "1.17.4",
-        "@injectivelabs/networks": "1.17.4",
-        "@injectivelabs/ts-types": "1.17.4",
+        "@injectivelabs/exceptions": "1.17.6",
+        "@injectivelabs/networks": "1.17.6",
+        "@injectivelabs/ts-types": "1.17.6",
         "axios": "^1.13.2",
         "bignumber.js": "^9.3.1",
         "http-status-codes": "^2.3.0",
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.2.tgz",
-      "integrity": "sha512-VuW2xJDnl1k8n8kjbdRSWawPRkwaVqUQNjE1TdeTawf0y0abGhtVJFTXCLfgpgGDBkO/Fj6kny8Dc/nvOW78MA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.3.tgz",
+      "integrity": "sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -2234,9 +2234,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "license": "MIT",
       "peer": true
     },
@@ -2297,54 +2297,54 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.7.4.tgz",
-      "integrity": "sha512-ynT3o6md8AJU9z6+iKl/Jahuie8D/epQBC0PDa8UkLNHlY+5zECfVzpWDky5DwcZ/9+ckXoZxacuLkZU4bgSxg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.9.0.tgz",
+      "integrity": "sha512-5uOd2YdDDG1KB1ttTkgkJcMtGUJwIDZ6CGExn5eMHI27f60cD1MQSJCCUoH7UbWYqJkeLhNX8WvagsSnTrRoQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.7.4",
-        "@wormhole-foundation/sdk-algorand-core": "4.7.4",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.7.4",
-        "@wormhole-foundation/sdk-aptos": "4.7.4",
-        "@wormhole-foundation/sdk-aptos-cctp": "4.7.4",
-        "@wormhole-foundation/sdk-aptos-core": "4.7.4",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.7.4",
-        "@wormhole-foundation/sdk-base": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.7.4",
-        "@wormhole-foundation/sdk-definitions": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
-        "@wormhole-foundation/sdk-evm-cctp": "4.7.4",
-        "@wormhole-foundation/sdk-evm-core": "4.7.4",
-        "@wormhole-foundation/sdk-evm-portico": "4.7.4",
-        "@wormhole-foundation/sdk-evm-tbtc": "4.7.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.7.4",
-        "@wormhole-foundation/sdk-solana": "4.7.4",
-        "@wormhole-foundation/sdk-solana-cctp": "4.7.4",
-        "@wormhole-foundation/sdk-solana-core": "4.7.4",
-        "@wormhole-foundation/sdk-solana-tbtc": "4.7.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.7.4",
-        "@wormhole-foundation/sdk-stacks": "4.7.4",
-        "@wormhole-foundation/sdk-stacks-core": "4.7.4",
-        "@wormhole-foundation/sdk-sui": "4.7.4",
-        "@wormhole-foundation/sdk-sui-cctp": "4.7.4",
-        "@wormhole-foundation/sdk-sui-core": "4.7.4",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "4.7.4"
+        "@wormhole-foundation/sdk-algorand": "4.9.0",
+        "@wormhole-foundation/sdk-algorand-core": "4.9.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-aptos": "4.9.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "4.9.0",
+        "@wormhole-foundation/sdk-aptos-core": "4.9.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-base": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-definitions": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-evm-cctp": "4.9.0",
+        "@wormhole-foundation/sdk-evm-core": "4.9.0",
+        "@wormhole-foundation/sdk-evm-portico": "4.9.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "4.9.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-solana": "4.9.0",
+        "@wormhole-foundation/sdk-solana-cctp": "4.9.0",
+        "@wormhole-foundation/sdk-solana-core": "4.9.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "4.9.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.0",
+        "@wormhole-foundation/sdk-stacks": "4.9.0",
+        "@wormhole-foundation/sdk-stacks-core": "4.9.0",
+        "@wormhole-foundation/sdk-sui": "4.9.0",
+        "@wormhole-foundation/sdk-sui-cctp": "4.9.0",
+        "@wormhole-foundation/sdk-sui-core": "4.9.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.7.4.tgz",
-      "integrity": "sha512-CnDAQ1t+7ZTP+3QzjDSdPDVclSdu/i4dE/eX5wePv8U7R6RkXEKP/fbtY8aGp3SDtP0x5pT64eNrNOCc9Yut4Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.9.0.tgz",
+      "integrity": "sha512-c9fDj2muwWrEWXqDexwIJa4DmfpXUuTzOlFPIOJ4miCYXWs3YoFEx3BECt4/r/q67X4G/W+fog4W0PJZ8lVWcA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2352,89 +2352,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.7.4.tgz",
-      "integrity": "sha512-EXeEkdb5Hm+M/fY8frjiakWpcXTepPTvgTMIAhQL4kQIhNbAanr0ToXGkaamruNHMbDd6tlXZJD8sSekkMWVIA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.9.0.tgz",
+      "integrity": "sha512-lh9cW3D91pmC+DrRXfKZ5DCGH85TokBQnyxWAeMrK5l3jdk6j7Iq+zrbgAkPxoqYWE3ewNQkRLg+Fo+qLL2yVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-algorand": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-OSiMX41u39oDg041fz3wB/CZqhpA3Y6TnULjxbpJqZe6C51LNTnLHxxy63yoiPo1rKP7PErukmaDVSN48Ax8SQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-JJMaNO1vVM0zcY2XnDSrCkgsDReLaiRtqFHKnOzw+tEsvrXrqVgRchOEEt+Yv3mPeKmKo7LGjnVaSTaLjCJMNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.7.4",
-        "@wormhole-foundation/sdk-algorand-core": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-algorand": "4.9.0",
+        "@wormhole-foundation/sdk-algorand-core": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.7.4.tgz",
-      "integrity": "sha512-8q2E09JF+9ZKEbb4MzbkOH3wZwl8sdA4WRtiFxZvu9gaUHz8D0laTBkfcHdHZbFogV0pkK9DUm4g4lRIkZFMkQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.9.0.tgz",
+      "integrity": "sha512-h3luSO0c1xI6AN8HKrpyMEyjOIPc5zqpBWVL2izdc5NUZaQkFTcJEuVM3h/berpJMQJ85E1uE1JKOCNjykjHXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.7.4.tgz",
-      "integrity": "sha512-sm1CX3PtkjN7P4uqbSwYxZI/z1zNZTmkhbCH5PTbpu1mlHld2FNrWfYAcK92edfHwBs/p4ZS6IrdhsrPs7vYAw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.9.0.tgz",
+      "integrity": "sha512-SkbQx/UPkJ4JWLTKkBDCCm+/DClW1aA5kX8BycLFByxLX/++vxf05PwGqcwNED/IIcZ7JnLxtCgU/6bfnfXNmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-aptos": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.7.4.tgz",
-      "integrity": "sha512-iaeAyTW7NdGSJRUvSZKJOLdm8eKux7F78fRgud+nKIKbzsb9uCS0AlRSvBrhvB9eRFOTf5qUTcQhh+S06hGdwA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.9.0.tgz",
+      "integrity": "sha512-wfxXUNkBVy475KR/5zOLrq50cl7xyC3HKEGtHdcaeKSqOZFyf8WYARIxuy9CiBktjBuqfWNrCuiXXwV7NjU4Ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-aptos": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-Tn+Os/JIIPPkMDsyU6/IXcY2wCTONHJBP36m06Rx5VHF39liNNfAirGMttwcwjTkCZ2gg+N69fkkHtkSpgv3GA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-Baag10sfCXTnYvmhFo3gnTU7Pclkl+EXUHR4xXE4CNnxIGwxEnGkGPa7xZx7u1tSGarNpk5EcidSPKqcuyzd5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.7.4",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-aptos": "4.9.0",
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.7.4.tgz",
-      "integrity": "sha512-S4JvnvhYRdCb0MYELptSKSqReX3m3N2licUsp915j25M/nOm6uOp5R4sjVMjruqbbNPmNhEDz+caDg1t1Ce9yw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.9.0.tgz",
+      "integrity": "sha512-tZ8m8NnMkRuS1uciWbU4VJ74UNXwpWHWeJ07QY7bOapd12hkPiKxb2ZFJETBTjCXTE4/cGmqFi3/rsLLsVPKIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2442,13 +2442,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.7.4.tgz",
-      "integrity": "sha512-YEQ7gSk6k9USyzKtPf3X7IojrAepHwUvSPaZeMT+xKCKJYpJ/ot3iS7bnY9MUhuaRd0RxBJbYE3Ys1fBzZTBFQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.9.0.tgz",
+      "integrity": "sha512-luBXnv3QOiNqH8g+yTPcksU7xfgc0PMIIrGAbI3YW52KJXW524nzxWkxRa0ckVEfi0P/H/RJTPUwoW6xbCySCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "4.7.4",
-        "@wormhole-foundation/sdk-definitions": "4.7.4",
+        "@wormhole-foundation/sdk-base": "4.9.0",
+        "@wormhole-foundation/sdk-definitions": "4.9.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2456,16 +2456,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.7.4.tgz",
-      "integrity": "sha512-hU4JD3cr3acZmI0BP/BZliqPwN4yD4Mk/noW+vbmi3SMkUigm983F8Qdt7+d+MIDW6zHDDQdzVaMF7Cl6WT7Ug==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.9.0.tgz",
+      "integrity": "sha512-VMfUhoixl1c+84wXE7+Wh/R/TB7jFCQJXWqYiWLia27gN2c6v8zKLuu6BzpBwcsjCmBA0xMEr2UDmFHwIXf8aA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2473,33 +2473,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.7.4.tgz",
-      "integrity": "sha512-KUlur5EnpYz+K12RODqY/i3B4SThMJgRN8YUfNpkaUrxnPpCofi4b6f6akvp1n+ns6KsxD9N45Fa8pZ/1K6Dsw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.9.0.tgz",
+      "integrity": "sha512-MH8tQypwgBQSR/Xa0vkq42Ca1gMJOXV0dNgTuHPu2ebtcNxoeUYKnj7Rt5tSLl3k85H/q3zHlZti4VKl1HoEfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.7.4.tgz",
-      "integrity": "sha512-Vaq3F/GSOxhNsPTIwoFgjY+6hLmoWw2apvF3PcHwecosdASA3E7ZaehB1saQgwe63r286dqikPTzcmL5fsVysQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.9.0.tgz",
+      "integrity": "sha512-hgG01A8TdZRxXQbayVDTmBwtxdF0p4MbzpDQn9Wds11P1AI3/RQfhgAv+3BdL3xDs9WOT1NAq6X1RDeoJXgewA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.9.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2507,37 +2507,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-EDxfS8iZpAvNuprOPaRG2UKFj8kQya2IZ4Ys7rMcT7RlbdKWoaE9OqzuS3Lq3laI+EOtXwLg2yLQixHhVdhLlw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-WhYleGQ1zFc+BU3HCX7a8UOGa08LaI+ky+1v4WAa9KPV/TfiSvx36cu57m6rxNQMOdP5YtWYr8nMNoDq7DMw8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-cosmwasm": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-cosmwasm": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.7.4.tgz",
-      "integrity": "sha512-xeMHYIMhktX/cK9VWFFyQNrS3Fy+JccBU+76v6fRx/L5yZ1m2XeTWDFq4JROZdv4EzrZQHdHqJlTWvXr+wbJYg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.9.0.tgz",
+      "integrity": "sha512-R5WfVat/IEB2ECJBv2c41CkIBmZoLnotafDdOJUfzXGPTIPVwweB7fjGQiMie/8pudUSDsVq4m1o6d/Q9xLx+Q==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "4.7.4"
+        "@wormhole-foundation/sdk-base": "4.9.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.7.4.tgz",
-      "integrity": "sha512-nV3AtbbAEwlOrwtWCDMLZobKLpV+vVvdv619WsLIkSp5w7d48ngjlmHWZL0WOgjXvfgNtD7gy3AtnsteabQJ6g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.9.0.tgz",
+      "integrity": "sha512-7X2MU2Oi8gA9p50mrNTyQxOMUcsZqLSMYl3RYgrGGYYK/GtEEy+Y/+46lUYwpY8ziZHdkWaUDXiRD7+lCQmrRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2545,14 +2545,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.7.4.tgz",
-      "integrity": "sha512-NfBltTdldq+qExpFNQZDG6WqIw43UUDPPdKfHyuclWi0wgfi1nOAfqM8v3mZE6mTLWcw94wHje6YfY4mJsPsZg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.9.0.tgz",
+      "integrity": "sha512-dZ0lKrhQiBSvANeFPSJWi8LFj/7I8W6xNNa0GYf9igsf1mcU3oCIBdRfEEchrmydACq9WE0OQ39Ye5Da73pYJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
-        "@wormhole-foundation/sdk-evm-core": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-evm-core": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2560,13 +2560,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.7.4.tgz",
-      "integrity": "sha512-mcAnZL0fY+XbY9uSjVq14hhCXNBfw+a+O3/ZNABBgS/5jh8/i7DQRz0fbVvk8xrOCdLWEtdneRCXC4beVTE6YA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.9.0.tgz",
+      "integrity": "sha512-Xk7c1fLy0cJGD6sNqPCAVxCSxbWHKqnczIIgTs6pzRQCmIYpGkOfFoa2oZ2OSfsN0bpa2+dD8QN6fIkLd70IRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2574,15 +2574,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.7.4.tgz",
-      "integrity": "sha512-E9Jwbz8g9WhcNBMNuZsdypJ2PCqN367x1G+r5ur7ft6Imq5HNHlgCakm2NwruUfepyAqiAZVPmPSFRDnGirEGw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.9.0.tgz",
+      "integrity": "sha512-uQcfBoCxkvBOjTbIw4oRN6v8mYxOBLwtD/rA4pyQpabelU2u0gIlXxFxnUPUMqWIFOx5f3z06Kx8jBEz3hBCKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
-        "@wormhole-foundation/sdk-evm-core": "4.7.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-evm-core": "4.9.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2590,14 +2590,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.7.4.tgz",
-      "integrity": "sha512-9Sc/P9fue2nn5240bD90eSdgAzT3cYXlW8YG6638eYrMAxhtL32cuMTaH+8m0PIqAlAfWMD2QzBSP7zEO8x4tw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.9.0.tgz",
+      "integrity": "sha512-2ElkqPLkxcQGLLDMw1lMRYtM0lgRCdCtaYkxwLDcyMuWGqL8/m0hGIrhIYk5+BMYnYw7zB4jlED23Bwlo7IOmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
-        "@wormhole-foundation/sdk-evm-core": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-evm-core": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2605,14 +2605,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-1IVDRxamQIH5Clk97Cva+B6yuuDO1zDmry2zZFfjuq8ThWU+Qgf3IjFUrJzQGfzJPIIk8VmuvfObKwsSIEioKA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-gN5zIWAhcAOo7pCT6K6tbVR+4CUMVN1piZQf7NgSgRtvTKNIhb/DNcFVEsTxdf6sggjh4qVI59HQ3jQyJPNy8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-evm": "4.7.4",
-        "@wormhole-foundation/sdk-evm-core": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-evm": "4.9.0",
+        "@wormhole-foundation/sdk-evm-core": "4.9.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2620,16 +2620,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.7.4.tgz",
-      "integrity": "sha512-iJWmiKDlEkbzpKc539HbHxRHJS8Qp3MECNpEFItHysvRwtsB/SiU73yt+GWk/L3LNIMgp9PO5RYVK4DNS8345A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.9.0.tgz",
+      "integrity": "sha512-H542TcPDY7jW4SlzRXKMVXRmZQauWmFp3dTg4DRVUhvzG24OQ4dlvTydT2MuLd2fSKZA1yWVFCCxtmFN1Nas9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
+        "@wormhole-foundation/sdk-connect": "4.9.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2637,150 +2637,150 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.7.4.tgz",
-      "integrity": "sha512-80B6ILpE3MOC11Bk+VcTtCQwEu50vuPUTZRuDH4crifCISgiCRUrfa1+QlY/2KjJUiv/tJsF2KB/2a5L84xPvQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.9.0.tgz",
+      "integrity": "sha512-DrYXbDnmKI3j8vfUB8nKMZx1jflGZhTnJYZSy/tTJQE2XB7PrRFMIeZLuTnnNbqPYLPZHGVp7QVD6p1gsISX4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-solana": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-solana": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.7.4.tgz",
-      "integrity": "sha512-3NYHuIqmEdDswp+7TxJRJKTni5Yuc+Y9vHDq8fqBMaPRzpBc6NiZpvrVLuEF4/rHlfXUPlHcUh260yEc6K/SUQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.9.0.tgz",
+      "integrity": "sha512-cJtdWcVJVT3C7OgNKjHWboWRPv7b4Vpa4E3qAgYb069z72QM1XLi3goORIGf6sZ1c0KDe5qOFh0wqOR9QVRPMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-solana": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-solana": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.7.4.tgz",
-      "integrity": "sha512-fT1c2oIslcvfSBtw02uAzXM7886s9W573w/l4uBHbFbICxMzE2uupwHJQLW8xlk8UjKY1VmPXoW6a25POJwEiA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.9.0.tgz",
+      "integrity": "sha512-gVoUc+Irg1JPH83rBkHNt1bt1aRyCdgpA1tQj4KDLMnikn7TdZSN2rMGKCKCnpERrsCQQWg1YqmFPUoi7h8UMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-solana": "4.7.4",
-        "@wormhole-foundation/sdk-solana-core": "4.7.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-solana": "4.9.0",
+        "@wormhole-foundation/sdk-solana-core": "4.9.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-OWEDmZCvhsicfxGbNGfzQX+0jz8qkWsGba0tBa4AdjBkihG7bz2U6omrmzM+VvBqlmfJYgpoL8DQTTcjqNYOeA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-/YpLwLBCyq0Xo8HBuzN+6R7NdC2XxkIU/A/eyfhlLTM347lE62+DFPHFEoZHF1jANKSRDwpxYFWgsblWanvn1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-solana": "4.7.4",
-        "@wormhole-foundation/sdk-solana-core": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-solana": "4.9.0",
+        "@wormhole-foundation/sdk-solana-core": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.7.4.tgz",
-      "integrity": "sha512-r3p2+fqrEGajzK/Q7iAY/5TQ8IsC6BobQQc16/SLmn6W/9zJPxgtlkPaTAhFNmX4o130UgCyLqJAK2SphUHCSQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.9.0.tgz",
+      "integrity": "sha512-JwfGAcmxcjpLFFDUTRt2m2WDjG1B66x4dwdOITMzQkYcvVANRJHTAKmUd9FXBGfMieBQ2y/dlnlR0aVZCak7RQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stacks/network": "^7.0.2",
         "@stacks/transactions": "^7.1.0",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.7.4.tgz",
-      "integrity": "sha512-XDCBTWxPRRWd2bRjdt8TxmbErCNbIDaUa38ZXELRquY+L9fPQkQLQfxMtuYpKlkFxFlSfO8HtxtF8nNMB6FuGw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.9.0.tgz",
+      "integrity": "sha512-kKKm572BV/ktsKaP+Qk5fBlKQCuFJuliJ6vQysRSHxDaw38bGZvjz0MeXFgUELuL3QxlWF50e9cNwJ31kMvy7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-stacks": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-stacks": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.7.4.tgz",
-      "integrity": "sha512-eN2SW1G4nW8uwRRk1Ocd5d+yh+/H3tdFfrgWUjXx3q/i+4N2V7UNC3xpeZTd4TFBH0+JVjq+FPWv16dDqy1SEQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.9.0.tgz",
+      "integrity": "sha512-V3+ab/25S3U5YMLvchruw+cfQOE3PuLD22pru4emlUAxsTmOCu6mho15EXy4BJvnAcnX0KU2vaR2wP/hzLZNhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.7.4.tgz",
-      "integrity": "sha512-eTKJZMW3q7fF3p8ioFelaD0HsfCBBp/PCfh/hu7i/eLuFomlZ8fwZ8sV5npcHXw42GsXa3pNaFxkErEutsYPBQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.9.0.tgz",
+      "integrity": "sha512-tX52xP0vfsvRx0O1wUeCMfk+acsRNu0lHXyPu415VXeSoMgiePyiHrcE9BoDRcFIrh1wvkQcfWrTrXTH1wOm4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-sui": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-sui": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.7.4.tgz",
-      "integrity": "sha512-jCO+L2SrcMmVlzX1xl27MV5Z7Q1iU7YCfn3YHm84c8T788lsenPGopqdxNMyFZEifVjhxqHu5hTdzAejmqXt1g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.9.0.tgz",
+      "integrity": "sha512-pflzuzqf6LuNDaqj4wt5mF+APKjzehwOyVNZZ+Vn2Az/hOHLvE4mhdIyf4nHVWP7K5y0kCp0Vmr5sBK7+8zpdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-sui": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-sui": "4.9.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.7.4.tgz",
-      "integrity": "sha512-TbGK/vp/jlDlIqkcoVnJlWZA+f9KrQZljcjKU4tlkgKOCPqzuwZyXJpK56CItEsVjbVu1MqJjTiZeYkiXOFGzA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.9.0.tgz",
+      "integrity": "sha512-vznzH5vs6PSXIowo35CvVZrPA6e8e9XYQPxYqxABvJicpV7HPy7vj8WN96pGYwq6TxGYhADXXUT/DoNwth7Y9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.7.4",
-        "@wormhole-foundation/sdk-sui": "4.7.4",
-        "@wormhole-foundation/sdk-sui-core": "4.7.4"
+        "@wormhole-foundation/sdk-connect": "4.9.0",
+        "@wormhole-foundation/sdk-sui": "4.9.0",
+        "@wormhole-foundation/sdk-sui-core": "4.9.0"
       },
       "engines": {
         "node": ">=16"
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/eyes": {
@@ -4936,6 +4936,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -5585,9 +5591,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.44.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.2.tgz",
-      "integrity": "sha512-nHY872t/T3flLpVsnvQT/89bwbrJwxaL917FDv7Oxy4E5FWIFkokRQOKXG3P+hgl30QYVZxi9o2SUHLnebycxw==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.45.0.tgz",
+      "integrity": "sha512-iVA9qrAgRdtpWa80lCZ6Jri6XzmLOwwA1wagX2HnKejKeliFLpON0KOdyfqvcy+gUpBVP59LBxP2aKiL3aj8fg==",
       "funding": [
         {
           "type": "github",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "4.7.4",
+    "@wormhole-foundation/sdk": "4.9.0",
     "axios": "^1.13.3",
     "sharp": "^0.34.5",
     "swagger-markdown": "^3.0.0"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,8 +20,8 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "4.9.0",
-    "axios": "^1.13.3",
+    "@wormhole-foundation/sdk": "4.9.1",
+    "axios": "^1.13.4",
     "sharp": "^0.34.5",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,14 +14,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^25.0.8",
+    "@types/node": "^25.0.10",
     "markdown-link-check": "^3.14.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
     "@wormhole-foundation/sdk": "4.7.4",
-    "axios": "^1.13.2",
+    "axios": "^1.13.3",
     "sharp": "^0.34.5",
     "swagger-markdown": "^3.0.0"
   }

--- a/scripts/src/chains/Moca.json
+++ b/scripts/src/chains/Moca.json
@@ -36,6 +36,11 @@
       "mainnet": true,
       "testnet": true,
       "devnet": false
+    },
+    "connect": {
+      "mainnet": true,
+      "testnet": false,
+      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/MonadTestnet.json
+++ b/scripts/src/chains/MonadTestnet.json
@@ -25,6 +25,11 @@
       "mainnet": false,
       "testnet": true,
       "devnet": false
+    },
+    "ntt": {
+      "mainnet": false,
+      "testnet": true,
+      "devnet": false
     }
   }
 }

--- a/scripts/src/chains/ZeroGravity.json
+++ b/scripts/src/chains/ZeroGravity.json
@@ -1,0 +1,36 @@
+{
+  "title": "0G (Zero Gravity)",
+  "homepage": "https://0g.ai/",
+  "devDocs": "https://docs.0g.ai/",
+  "testnet": {
+    "name": "Testnet",
+    "id": "16602"
+  },
+  "mainnet": {
+    "name": "Mainnet",
+    "id": "16661"
+  },
+  "faucet": {
+    "url": "https://faucet.0g.ai/",
+    "token": "0G",
+    "description": "0G Official Faucet"
+  },
+  "explorer": [
+    {
+      "url": "https://chainscan.0g.ai",
+      "description": "Zero Gravity Mainnet Explorer"
+    }
+  ],
+  "products": {
+    "tokenBridge": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": false
+    },
+    "multigov": {
+      "mainnet": true,
+      "testnet": true,
+      "devnet": true
+    }
+  }
+}

--- a/scripts/src/chains/linea.json
+++ b/scripts/src/chains/linea.json
@@ -42,7 +42,7 @@
     },
     "ntt": {
       "mainnet": true,
-      "testnet": false,
+      "testnet": true,
       "devnet": false
     },
     "connect": {

--- a/scripts/src/generated/connect-support.json
+++ b/scripts/src/generated/connect-support.json
@@ -19,6 +19,7 @@
     "Mantle",
     "MegaETH",
     "Mezo",
+    "Moca",
     "Monad",
     "Moonbeam",
     "Optimism",

--- a/scripts/src/generated/ntt-support.json
+++ b/scripts/src/generated/ntt-support.json
@@ -46,6 +46,7 @@
     "Fantom",
     "Fogo",
     "Ink",
+    "Linea",
     "Mezo",
     "Moca",
     "MonadTestnet",

--- a/scripts/src/generated/ntt-support.json
+++ b/scripts/src/generated/ntt-support.json
@@ -48,6 +48,7 @@
     "Ink",
     "Mezo",
     "Moca",
+    "MonadTestnet",
     "Moonbeam",
     "Optimism",
     "OptimismSepolia",


### PR DESCRIPTION
This pull request updates dependencies and adds new chain configuration data to the project. The most significant changes include upgrading core packages, introducing a new chain configuration for Zero Gravity, and updating existing chain JSON files with new product information.

Dependency updates:

* Upgraded `@wormhole-foundation/sdk` from version 4.7.4 to 4.9.0 for improved features and compatibility.
* Updated `axios` from 1.13.2 to 1.13.3 and `@types/node` from 25.0.8 to 25.0.10 in `scripts/package.json`.

New chain configuration:

* Added a new file `ZeroGravity.json` with configuration details for the 0G (Zero Gravity) blockchain, including network IDs, faucet, explorer, and supported products.

Enhancements to existing chain configurations:

* Added a `connect` product entry to `Moca.json`, specifying its availability on mainnet only.
* Added an `ntt` product entry to `MonadTestnet.json`, specifying its availability on testnet only.

Goes with: https://github.com/wormhole-foundation/wormhole-docs/pull/789