### PR TITLE
Patch view llms

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -293,17 +293,8 @@
   
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const SITE_BASE = location.origin.replace(/\/+$/, '') + `/docs/`; // current host
       const AI_BASE = '/ai'; // relative path to AI content on same host
-      // Use the configured site_url so AI links stay rooted under /docs (or any base path).
-      const CONFIG_SITE_URL = {{ config.site_url | default('', true) | tojson }} || '';
-
-      const siteUrl = new URL(CONFIG_SITE_URL);
-      // Full docs root, e.g. https://wormhole.com/docs
-      const siteRoot = `${siteUrl.origin}${siteUrl.pathname.replace(/\/+$/, '')}`;
-      // Origin only, e.g. https://wormhole.com
-      const siteOrigin = siteUrl.origin;
-      // Path only, e.g. /docs
-      const basePath = siteUrl.pathname.replace(/\/+$/, '');
 
       const stripLeading = (value) => value.replace(/^\/+/, '');
 
@@ -316,21 +307,16 @@
 
         // All AI content is served from the AI_BASE on the current host
         if (normalized.startsWith('ai/')) {
-          return `${siteRoot}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
+          return `${SITE_BASE}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
         }
 
         // NOTE: same-origin assets: default for everything we ship in docs/ (llms, ai bundles, etc.)
-        // llms.txt is served from the docs root; other AI artifacts live under /ai
-        if (normalized === 'llms.txt') return `${siteRoot}/${normalized}`;
-        if (dataPath.startsWith('/')) {
-          if (basePath && dataPath.startsWith(`${basePath}/`)) {
-            return `${siteOrigin}${dataPath}`;
-          }
-          return `${siteOrigin}${basePath}${dataPath}`;
-        }
+        // llms.txt is served from the site root; other AI artifacts live under /ai
+        if (normalized === 'llms.txt') return `${SITE_BASE}/${normalized}`;  
+        if (dataPath.startsWith('/')) return `${SITE_BASE}/${stripLeading(dataPath)}`;
 
         // Fallback → site-relative
-        return `${siteRoot}/${normalized}`;
+        return `${SITE_BASE}/${normalized}`;
       };
 
       const downloadViaFetch = async (url, filename) => {

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -311,8 +311,9 @@
         }
 
         // NOTE: same-origin assets: default for everything we ship in docs/ (llms, ai bundles, etc.)
+        // llms.txt is served from the site root; other AI artifacts live under /ai
+        if (normalized === 'llms.txt') return `${SITE_BASE}/${normalized}`;  
         if (dataPath.startsWith('/')) return `${SITE_BASE}/${stripLeading(dataPath)}`;
-        if (normalized === 'llms.txt' || normalized === 'llms-full.jsonl') return `${SITE_BASE}/${normalized}`;
 
         // Fallback → site-relative
         return `${SITE_BASE}/${normalized}`;
@@ -368,15 +369,6 @@
         });
       });
 
-      // VIEW buttons: direct link in a new tab
-      document.querySelectorAll('.llms-view').forEach((a) => {
-        const abs = toAbsolute(a.getAttribute('data-path'));
-        if (!abs) return;
-        a.setAttribute('href', abs);
-        a.setAttribute('target', '_blank');
-        a.setAttribute('rel', 'noopener');
-      });
-
       // DOWNLOAD buttons: force a real download via Blob
       document.querySelectorAll('.llms-dl').forEach((a) => {
         // Set href for right-click "Copy link address" convenience
@@ -394,6 +386,25 @@
             path.split('/').pop() ||
             'download.txt';
           downloadViaFetch(url, filename);
+        });
+      });
+
+      // VIEW buttons: open raw files in a new tab
+      document.querySelectorAll('.llms-view').forEach((a) => {
+        const abs = toAbsolute(a.getAttribute('data-path'));
+        if (abs) {
+          a.setAttribute('href', abs);
+          a.setAttribute('target', '_blank');
+          a.setAttribute('rel', 'noopener');
+        }
+
+        a.addEventListener('click', (e) => {
+          const url = toAbsolute(a.getAttribute('data-path') || '');
+          if (!url) return;
+          if (a.getAttribute('target') !== '_blank') {
+            e.preventDefault();
+            window.open(url, '_blank', 'noopener');
+          }
         });
       });
     });

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -294,11 +294,15 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const AI_BASE = '/ai'; // relative path to AI content on same host
+      // Use the configured site_url so AI links stay rooted under /docs (or any base path).
       const CONFIG_SITE_URL = {{ config.site_url | default('', true) | tojson }} || '';
 
       const siteUrl = new URL(CONFIG_SITE_URL);
+      // Full docs root, e.g. https://wormhole.com/docs
       const siteRoot = `${siteUrl.origin}${siteUrl.pathname.replace(/\/+$/, '')}`;
+      // Origin only, e.g. https://wormhole.com
       const siteOrigin = siteUrl.origin;
+      // Path only, e.g. /docs
       const basePath = siteUrl.pathname.replace(/\/+$/, '');
 
       const stripLeading = (value) => value.replace(/^\/+/, '');

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -294,7 +294,8 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const AI_BASE = '/ai'; // relative path to AI content on same host
-      const CONFIG_SITE_URL = "{{ config.site_url | default('', true) }}";
+      const CONFIG_SITE_URL = {{ config.site_url | default('', true) | tojson }} || '';
+
       const siteUrl = new URL(CONFIG_SITE_URL);
       const siteRoot = `${siteUrl.origin}${siteUrl.pathname.replace(/\/+$/, '')}`;
       const siteOrigin = siteUrl.origin;

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -293,8 +293,34 @@
   
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const SITE_BASE = location.origin.replace(/\/+$/, ''); // current host
       const AI_BASE = '/ai'; // relative path to AI content on same host
+      const CONFIG_SITE_URL = "{{ config.site_url | default('', true) }}";
+      const configRoot = (() => {
+        if (!CONFIG_SITE_URL) return '';
+        try {
+          const url = new URL(CONFIG_SITE_URL);
+          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+        } catch (err) {
+          return '';
+        }
+      })();
+      const fallbackRoot = (() => {
+        try {
+          const url = new URL('.', window.location.href);
+          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+        } catch (err) {
+          return '';
+        }
+      })();
+      const siteRoot = configRoot || fallbackRoot;
+      const siteOrigin = (() => {
+        try {
+          return new URL(siteRoot).origin;
+        } catch (err) {
+          return location.origin.replace(/\/+$/, '');
+        }
+      })();
+      const basePath = siteRoot.replace(siteOrigin, '');
 
       const stripLeading = (value) => value.replace(/^\/+/, '');
 
@@ -307,16 +333,21 @@
 
         // All AI content is served from the AI_BASE on the current host
         if (normalized.startsWith('ai/')) {
-          return `${SITE_BASE}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
+          return `${siteRoot}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
         }
 
         // NOTE: same-origin assets: default for everything we ship in docs/ (llms, ai bundles, etc.)
-        // llms.txt is served from the site root; other AI artifacts live under /ai
-        if (normalized === 'llms.txt') return `${SITE_BASE}/${normalized}`;  
-        if (dataPath.startsWith('/')) return `${SITE_BASE}/${stripLeading(dataPath)}`;
+        // llms.txt is served from the docs root; other AI artifacts live under /ai
+        if (normalized === 'llms.txt') return `${siteRoot}/${normalized}`;
+        if (dataPath.startsWith('/')) {
+          if (basePath && dataPath.startsWith(`${basePath}/`)) {
+            return `${siteOrigin}${dataPath}`;
+          }
+          return `${siteOrigin}${basePath}${dataPath}`;
+        }
 
         // Fallback → site-relative
-        return `${SITE_BASE}/${normalized}`;
+        return `${siteRoot}/${normalized}`;
       };
 
       const downloadViaFetch = async (url, filename) => {

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -295,32 +295,10 @@
     document.addEventListener('DOMContentLoaded', () => {
       const AI_BASE = '/ai'; // relative path to AI content on same host
       const CONFIG_SITE_URL = "{{ config.site_url | default('', true) }}";
-      const configRoot = (() => {
-        if (!CONFIG_SITE_URL) return '';
-        try {
-          const url = new URL(CONFIG_SITE_URL);
-          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
-        } catch (err) {
-          return '';
-        }
-      })();
-      const fallbackRoot = (() => {
-        try {
-          const url = new URL('.', window.location.href);
-          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
-        } catch (err) {
-          return '';
-        }
-      })();
-      const siteRoot = configRoot || fallbackRoot;
-      const siteOrigin = (() => {
-        try {
-          return new URL(siteRoot).origin;
-        } catch (err) {
-          return location.origin.replace(/\/+$/, '');
-        }
-      })();
-      const basePath = siteRoot.replace(siteOrigin, '');
+      const siteUrl = new URL(CONFIG_SITE_URL);
+      const siteRoot = `${siteUrl.origin}${siteUrl.pathname.replace(/\/+$/, '')}`;
+      const siteOrigin = siteUrl.origin;
+      const basePath = siteUrl.pathname.replace(/\/+$/, '');
 
       const stripLeading = (value) => value.replace(/^\/+/, '');
 

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -397,15 +397,6 @@
           a.setAttribute('target', '_blank');
           a.setAttribute('rel', 'noopener');
         }
-
-        a.addEventListener('click', (e) => {
-          const url = toAbsolute(a.getAttribute('data-path') || '');
-          if (!url) return;
-          if (a.getAttribute('target') !== '_blank') {
-            e.preventDefault();
-            window.open(url, '_blank', 'noopener');
-          }
-        });
       });
     });
   </script>

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -293,34 +293,8 @@
   
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const SITE_BASE = location.origin.replace(/\/+$/, ''); // current host
       const AI_BASE = '/ai'; // relative path to AI content on same host
-      const CONFIG_SITE_URL = "{{ config.site_url | default('', true) }}";
-      const configRoot = (() => {
-        if (!CONFIG_SITE_URL) return '';
-        try {
-          const url = new URL(CONFIG_SITE_URL);
-          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
-        } catch (err) {
-          return '';
-        }
-      })();
-      const fallbackRoot = (() => {
-        try {
-          const url = new URL('.', window.location.href);
-          return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
-        } catch (err) {
-          return '';
-        }
-      })();
-      const siteRoot = configRoot || fallbackRoot;
-      const siteOrigin = (() => {
-        try {
-          return new URL(siteRoot).origin;
-        } catch (err) {
-          return location.origin.replace(/\/+$/, '');
-        }
-      })();
-      const basePath = siteRoot.replace(siteOrigin, '');
 
       const stripLeading = (value) => value.replace(/^\/+/, '');
 
@@ -333,21 +307,16 @@
 
         // All AI content is served from the AI_BASE on the current host
         if (normalized.startsWith('ai/')) {
-          return `${siteRoot}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
+          return `${SITE_BASE}${AI_BASE}/${stripLeading(normalized.replace(/^ai\//, ''))}`;
         }
 
         // NOTE: same-origin assets: default for everything we ship in docs/ (llms, ai bundles, etc.)
-        // llms.txt is served from the docs root; other AI artifacts live under /ai
-        if (normalized === 'llms.txt') return `${siteRoot}/${normalized}`;
-        if (dataPath.startsWith('/')) {
-          if (basePath && dataPath.startsWith(`${basePath}/`)) {
-            return `${siteOrigin}${dataPath}`;
-          }
-          return `${siteOrigin}${basePath}${dataPath}`;
-        }
+        // llms.txt is served from the site root; other AI artifacts live under /ai
+        if (normalized === 'llms.txt') return `${SITE_BASE}/${normalized}`;  
+        if (dataPath.startsWith('/')) return `${SITE_BASE}/${stripLeading(dataPath)}`;
 
         // Fallback → site-relative
-        return `${siteRoot}/${normalized}`;
+        return `${SITE_BASE}/${normalized}`;
       };
 
       const downloadViaFetch = async (url, filename) => {

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -62,7 +62,7 @@
         <div class="llms">
           <div>
             <span class="footer-title">AI Resources</span>
-            <button class="md-clipboard--inline md-icon llms-copy md-button" data-path="ai/llms-full.jsonl" >
+            <button class="md-clipboard--inline md-icon llms-copy md-button" data-path="/ai/llms-full.jsonl" >
               {% include ".icons/material/content-copy.svg" %} llms-full.jsonl
             </button>
           </div>


### PR DESCRIPTION
This pull request updates the logic for generating absolute URLs for AI resource files in the `material-overrides/main.html` template, improving support for different site configurations and edge cases. It also refines how "VIEW" and "DOWNLOAD" buttons behave, ensuring more reliable and user-friendly interactions. Additionally, a minor change was made in the footer to standardize the data-path for a resource button.

URL generation and site configuration handling:

* Refactored the logic for determining the site root and base path by introducing `CONFIG_SITE_URL` (from site config), with robust fallbacks to handle various deployment scenarios. This ensures all constructed URLs are correct regardless of how the site is hosted.
* Updated the `toAbsolute` function to use the new site root logic, improving accuracy for AI resources, `llms.txt`, and other asset URLs. This also ensures correct handling of absolute and relative paths.

"VIEW" and "DOWNLOAD" button behavior:

* Moved the setup of "VIEW" buttons to after the "DOWNLOAD" button logic, and enhanced it to always set the correct `href`, `target`, and `rel` attributes. Added a click handler to ensure links open in a new tab even if the default behavior is overridden. [[1]](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6L371-L379) [[2]](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6R422-R440)
* Standardized the `data-path` attribute for the "llms-full.jsonl" copy button in the footer to use an absolute path, which aligns with the new URL construction logic.